### PR TITLE
run jobs that require virtualenvs correctly

### DIFF
--- a/lib/disco/worker/__init__.py
+++ b/lib/disco/worker/__init__.py
@@ -213,7 +213,12 @@ class Worker(dict):
         """
         :return: :ref:`jobenvs` dict.
         """
-        return {'PYTHONPATH': ':'.join([path.strip('/') for path in sys.path])}
+        def mangle_path(path):
+            if '.virtualenvs' in path:
+                return path
+            else:
+                return path.strip('/')
+        return {'PYTHONPATH': ':'.join([mangle_path(path) for path in sys.path])}
 
     def jobhome(self, job, **jobargs):
         """


### PR DESCRIPTION
Disco can't run code in a virtualenv. If it weren't stripping off the "/" from every path in sys.path, it would be able to use the virtualenv perfectly well -- either on the same machine, or another machine that has the same virtualenv.

Here's a patch that detects whether a given path is in a wrapped virtualenv by testing whether the substring ".virtualenvs" is in the path. (There should be a better test, ideally.) If so, it leaves the path alone.

Disco must still be installed globally, but this at least makes it _possible_ to run code whose modules aren't globally installed.
