### PR TITLE
Added notes about firewall to troubleshooting doc

### DIFF
--- a/doc/start/troubleshoot.rst
+++ b/doc/start/troubleshoot.rst
@@ -177,12 +177,20 @@ there's probably something wrong either with your
           and vice versa.
           Aliasing is not allowed.
 
-.. warning::
-   Future versions of Disco may allow you to specify a port range for Erlang to use,
-   however the current version of Disco does not,
-   which may cause problems if you are using a firewall.
-   If you have a firewall running inside your cluster,
-   you may need to turn it off in order for Disco to work properly.
+Is your firewall configued correctly?
+-------------------------------------
+
+Disco requires a number of ports to be accessible to function properly.
+
+- 22 - SSH
+- 8990 - DDFS web API
+- 8989 - Disco web interface/API. Must be unblocked on slaves and the master.
+- 4369 - Erlang port mapper
+- 30000 to 65535 - Communication between Erlang slaves
+.. note::
+   Future versions of Disco may allow you to specify a port range for Erlang to
+   use. However, the current version of Disco does not, so you must open up the
+   entire port range.
 
 Do workers run?
 ---------------


### PR DESCRIPTION
The previous docs simply said not to use a firewall. I don't have this option on EC2, so I spent the time to figure what ports are needed, and I added them to the docs.
