### PR TITLE
Fix  of proxy on the client side.

### DIFF
--- a/lib/disco/schemes/scheme_disco.py
+++ b/lib/disco/schemes/scheme_disco.py
@@ -10,7 +10,9 @@ def open(url, task=None):
                                              ddfs_data=task.ddfs_data)
     else:
         scheme, netloc, path = util.urlsplit(url, localhost=None)
-    return comm.open_url(util.urljoin((scheme, netloc, path)))
+
+    u = util.proxy_url(util.urljoin((scheme, netloc, path)))
+    return comm.open_url(u)
 
 def input_stream(fd, size, url, params):
     """

--- a/lib/disco/util.py
+++ b/lib/disco/util.py
@@ -279,7 +279,7 @@ def parse_dir(dir, partition=None):
 def proxy_url(url, proxy=DiscoSettings()['DISCO_PROXY']):
     if proxy:
         scheme, (host, port), path = urlsplit(url)
-        return '%s/disco/node/%s/%s' % (proxy, host, path)
+        return '%s/proxy/%s/GET/%s' % (proxy, host, path)
     return url
 
 def read_index(dir):


### PR DESCRIPTION
Note that DISCO_PROXY has to pint to the http proxy not to disco master. I also had to set DISCO_MASTER_HOST to localhost. The complete command to run count words is::

  ssh actual_disco_master -L8999:localhost:8999 -L8989:localhost:8989
  DISCO_PROXY=http://localhost:8999 DISCO_MASTER_HOST=localhost python count_words.py
