### PR TITLE
"Unicode Fix" for data transmission in Python 2.7

### DIFF
--- a/lib/disco/comm.py
+++ b/lib/disco/comm.py
@@ -52,6 +52,9 @@ def resolveuri(baseuri, uri):
 def request(method, url, data=None, headers={}, sleep=0):
     scheme, netloc, path = urlsplit(urlresolve(url))
 
+    if data is not None:
+        data = bytearray(data)
+
     try:
         conn = HTTPConnection(str(netloc))
         conn.request(method, '/%s' % path, body=data, headers=headers)

--- a/lib/disco/comm.py
+++ b/lib/disco/comm.py
@@ -52,8 +52,14 @@ def resolveuri(baseuri, uri):
 def request(method, url, data=None, headers={}, sleep=0):
     scheme, netloc, path = urlsplit(urlresolve(url))
 
-    if data is not None:
-        data = bytearray(data)
+    # This fixes a problem with Unicode errors in Python 2.7
+    # works in Python 2.6 as well, but not earlier versions
+    try:
+        if data is not None:
+            data = bytearray(data)
+    except NameError:
+        # In Python < 2.6, bytearray doesn't exist
+        pass
 
     try:
         conn = HTTPConnection(str(netloc))


### PR DESCRIPTION
This fixes a strange unicode error that happens in Python 2.7 when trying to ddfs.chunk,
