### PR TITLE
The Pid of the replicator is passed along correctly inside the State.

### DIFF
--- a/master/src/ddfs/ddfs_gc_main.erl
+++ b/master/src/ddfs/ddfs_gc_main.erl
@@ -416,7 +416,7 @@ handle_cast({gc_done, Node, NodeStats}, #state{phase = gc,
                  % and then iterate over all the blobs.
                  RRPid = start_replicator(self()),
                  Start = ets:first(gc_blobs),
-                 rereplicate_blob(S, Start),
+                 rereplicate_blob(S#state{rr_pid = RRPid}, Start),
                  S#state{phase = rr_blobs, rr_pid = RRPid};
              Remaining ->
                  error_logger:info_report({"GC: nodes pending in gc", Remaining}),


### PR DESCRIPTION
The State was not updated, so that it would contain the Pid of the replicator. When the time came in try_put_blob/4 to send a message to the RR process, RR would be undefined.
