### PR TITLE
Cleanup by applying tidier to the codebase of ddfs

### DIFF
--- a/master/src/ddfs/ddfs_gc_node.erl
+++ b/master/src/ddfs/ddfs_gc_node.erl
@@ -1,6 +1,6 @@
 -module(ddfs_gc_node).
 -export([start_gc_node/4]).
--export([gc_node_init/3]).
+
 -include_lib("kernel/include/file.hrl").
 
 -include("config.hrl").
@@ -12,7 +12,7 @@
 
 -spec start_gc_node(node(), pid(), erlang:timestamp(), phase()) -> pid().
 start_gc_node(Node, Master, Now, Phase) ->
-    spawn_link(Node, ?MODULE, gc_node_init, [Master, Now, Phase]).
+    spawn_link(Node, fun () -> gc_node_init(Master, Now, Phase) end).
 
 -spec gc_node_init(pid(), erlang:timestamp(), phase()) -> 'ok'.
 gc_node_init(Master, Now, Phase) ->

--- a/master/src/ddfs/ddfs_master.erl
+++ b/master/src/ddfs/ddfs_master.erl
@@ -165,9 +165,9 @@ handle_call(gc_stats, _F, #state{gc_stats = Stats} = S) ->
     {reply, {ok, Stats}, S};
 
 handle_call({choose_write_nodes, K, Exclude}, _,
-            #state{write_blacklist = WBL, gc_blacklist = GBL} = S) ->
+            #state{nodes = N, write_blacklist = WBL, gc_blacklist = GBL} = S) ->
     BL = lists:umerge(WBL, GBL),
-    {reply, do_choose_write_nodes(S#state.nodes, K, Exclude, BL), S};
+    {reply, do_choose_write_nodes(N, K, Exclude, BL), S};
 
 handle_call({new_blob, Obj, K, Exclude}, _,
             #state{nodes = N, gc_blacklist = GBL, write_blacklist = WBL} = S) ->

--- a/master/src/ddfs/ddfs_node.erl
+++ b/master/src/ddfs/ddfs_node.erl
@@ -183,14 +183,14 @@ do_get_diskspace(#state{vols = Vols}) ->
                              | {'noreply', #state{}}.
 do_put_blob(_BlobName, _From, #state{vols = []} = S) ->
     {reply, {error, no_volumes}, S};
-do_put_blob(BlobName, {Pid, _Ref} = From, #state{putq = Q} = S) ->
+do_put_blob(BlobName, {Pid, _Ref} = From,
+	    #state{putq = Q, nodename = NodeName,
+		   root = Root, vols = Vols} = S) ->
     Reply = fun() ->
-                    {_Space, VolName} = choose_vol(S#state.vols),
+                    {_Space, VolName} = choose_vol(Vols),
                     {ok, Local, Url} = ddfs_util:hashdir(list_to_binary(BlobName),
-                                                         S#state.nodename,
-                                                         "blob",
-                                                         S#state.root,
-                                                         VolName),
+                                                         NodeName, "blob",
+                                                         Root, VolName),
                     case ddfs_util:ensure_dir(Local) of
                         ok ->
                             gen_server:reply(From, {ok, Local, Url});
@@ -259,7 +259,7 @@ do_put_tag_data(Tag, Data, S) ->
 -spec do_put_tag_commit(tagname(), [{node(), volume_name()}], #state{}) ->
                        {{'ok', url()} | {'error', _}, #state{}}.
 do_put_tag_commit(Tag, TagVol, S) ->
-    {value, {_, VolName}} = lists:keysearch(node(), 1, TagVol),
+    {_, VolName} = lists:keyfind(node(), 1, TagVol),
     {ok, Local, Url} = ddfs_util:hashdir(Tag,
                                          S#state.nodename,
                                          "tag",

--- a/master/src/ddfs/ddfs_tag_util.erl
+++ b/master/src/ddfs/ddfs_tag_util.erl
@@ -71,7 +71,7 @@ encode_tagcontent_secure(D) ->
         ]})).
 
 lookup(Key, List) ->
-   {value, {_, Value}} = lists:keysearch(Key, 1, List),
+   {_, Value} = lists:keyfind(Key, 1, List),
    Value.
 lookup(Key, Default, List) ->
     proplists:get_value(Key, List, Default).

--- a/master/src/ddfs/ddfs_util.erl
+++ b/master/src/ddfs/ddfs_util.erl
@@ -110,7 +110,7 @@ to_hex(Int, L) ->
 hashdir(Name, Host, Type, Root, Vol) ->
     <<D0:8, _/binary>> = erlang:md5(Name),
     D1 = to_hex(D0),
-    Dir = lists:flatten([if length(D1) == 1 -> "0"; true -> "" end, D1]),
+    Dir = lists:flatten([case D1 of [_] -> "0"; _ -> "" end, D1]),
     Path = filename:join([Vol, Type, Dir]),
     Url = list_to_binary(["disco://", Host, "/ddfs/", Path, "/", Name]),
     Local = filename:join(Root, Path),

--- a/master/src/ddfs/ddfs_web.erl
+++ b/master/src/ddfs/ddfs_web.erl
@@ -102,9 +102,9 @@ op('GET', "/ddfs/ctrl/safe_gc_blacklist", Req) ->
 op('GET', "/ddfs/new_blob/" ++ BlobName, Req) ->
     BlobK = list_to_integer(disco:get_setting("DDFS_BLOB_REPLICAS")),
     QS = Req:parse_qs(),
-    K = case lists:keysearch("replicas", 1, QS) of
+    K = case lists:keyfind("replicas", 1, QS) of
             false -> BlobK;
-            {value, {_, X}} -> list_to_integer(X)
+            {_, X} -> list_to_integer(X)
     end,
     Exc = parse_exclude(lists:keysearch("exclude", 1, QS)),
     case ddfs:new_blob(ddfs_master, BlobName, K, Exc) of
@@ -222,8 +222,8 @@ op(_, _, Req) ->
     Req:not_found().
 
 is_set(Flag, QS) ->
-    case lists:keysearch(Flag, 1, QS) of
-        {value, {_, [_|_]}} ->
+    case lists:keyfind(Flag, 1, QS) of
+        {_, [_|_]} ->
             true;
         _ ->
             false


### PR DESCRIPTION
There are too many changes that are suggested by tidier for the entire code base.
So, I've thought it may be better to split the cleanups in separate chunks which can be tested independently.
This pull request cleans up all files of 'ddfs'.  Once this is included in 'master' and tested that it works, I will send the rest.
