### PR TITLE
DDFS.pull was ignoring proxy settings

### DIFF
--- a/lib/disco/ddfs.py
+++ b/lib/disco/ddfs.py
@@ -222,6 +222,12 @@ class DDFS(object):
             if blobfilter(self.blob_name(repl[0])):
                 random.shuffle(repl)
                 for url in repl:
+                    url = self._resolve(
+                        proxy_url(url,
+                                  meth='GET',
+                                  proxy=self.proxy,
+                                  to_master=False)
+                    )
                     try:
                         yield open_remote(url)
                         break


### PR DESCRIPTION
Resolve disco proxy urls for `DDFS.pull()` method

note: I have checked other DDFS methods and only `pull` wasn't working with disco proxy settings.
