### PR TITLE
python warnings breaks worker protocol

### DIFF
--- a/lib/disco/worker/__init__.py
+++ b/lib/disco/worker/__init__.py
@@ -98,6 +98,8 @@ class Worker(dict):
     :type  profile: bool
     :param profile: determines whether :meth:`run` will be profiled.
     """
+    stderr = sys.stderr
+
     def __init__(self, **kwargs):
         super(Worker, self).__init__(self.defaults())
         self.update(kwargs)
@@ -322,7 +324,7 @@ class Worker(dict):
         """
         try:
             sys.stdin = NonBlockingInput(sys.stdin, timeout=600)
-            sys.stdout = MessageWriter(cls)
+            sys.stdout = sys.stderr = MessageWriter(cls)
             cls.send('WORKER', {'pid': os.getpid(), 'version': "1.0"})
             task = cls.get_task()
             job, jobargs = task.jobobjs
@@ -342,7 +344,7 @@ class Worker(dict):
     def send(cls, type, payload=''):
         from disco.json import dumps, loads
         body = dumps(payload)
-        sys.stderr.write('%s %d %s\n' % (type, len(body), body))
+        cls.stderr.write('%s %d %s\n' % (type, len(body), body))
         spent, rtype = sys.stdin.t_read_until(' ')
         spent, rsize = sys.stdin.t_read_until(' ', spent=spent)
         spent, rbody = sys.stdin.t_read(int(rsize) + 1, spent=spent)


### PR DESCRIPTION
`warnings.showwarning` writes messages to `sys.stderr` breaking disco
worker protocol.

This change wraps any write to stderr the same way stdout is intercepted
by with a MessageWriter instance
