### PR TITLE
expose "ddfs" and "disco" scripts to clients

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ install: install-core install-node install-master
 
 uninstall: uninstall-master uninstall-node
 
-install-core:
+install-core: $(TARGETBIN)/disco $(TARGETBIN)/ddfs
 	(cd lib && $(PY_INSTALL))
 
 install-discodb: contrib
@@ -121,7 +121,6 @@ install-examples: $(TARGETLIB)/examples
 
 install-master: master \
 	$(TARGETDAT)/$(WWW) \
-	$(TARGETBIN)/disco $(TARGETBIN)/ddfs \
 	$(TARGETCFG)/settings.py
 
 uninstall-master:


### PR DESCRIPTION
When installing python-disco on clients it is convenient to have `ddfs` and `disco` scripts available to query jobs statuses or ddfs tags.

This change changes this scripts to be shipped with python-disco instead of disco-master.
