### PR TITLE
Fixed job deletion from UI when job has quotes in name.

### DIFF
--- a/master/www/js/job.js
+++ b/master/www/js/job.js
@@ -1,5 +1,6 @@
 $(document).ready(function(){
-    var job = new Job(document.location.search.substr(6));
+    var jobname = decodeURI(document.location.search.substr(6));
+    var job = new Job(jobname);
     $("#hd #title").append(job.name);
     $("#kill_job").click(job.kill);
     $("#purge_job").click(job.purge);


### PR DESCRIPTION
Fix for issue #274.
Jobs with quotes in name could be deleted now.
