### PR TITLE
Change logging over to SYSLOG via lager_syslog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ EBIN  = master/ebin
 ESRC  = master/src
 EDEP  = master/deps
 
-DEPS     = mochiweb lager
+DEPS     = mochiweb lager lager_syslog syslog
 EDEPS    = $(foreach dep,$(DEPS),$(EDEP)/$(dep)/ebin)
 ELIBS    = $(ESRC) $(ESRC)/ddfs
 ESOURCES = $(foreach lib,$(ELIBS),$(wildcard $(lib)/*.erl))
@@ -107,7 +107,7 @@ doc-clean:
 doc-test:
 	$(MAKE) -C doc doctest -e
 
-install: install-core install-node install-master
+install: install-core install-node install-master install-erl-syslog
 
 uninstall: uninstall-master uninstall-node
 
@@ -137,6 +137,8 @@ uninstall-node:
 	- rm -Rf $(TARGETLIB) $(TARGETSRV)
 
 install-tests: $(TARGETLIB)/ext $(TARGETLIB)/tests
+
+install-erl-syslog: $(TARGETLIB)/$(EDEP)/syslog/priv/syslog.so
 
 dialyzer: $(EPLT) master
 	$(DIALYZER) --get_warnings -Wunmatched_returns -Werror_handling --plt $(EPLT) -r $(EBIN)

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ uninstall-node:
 
 install-tests: $(TARGETLIB)/ext $(TARGETLIB)/tests
 
-install-erl-syslog: $(TARGETLIB)/$(EDEP)/syslog/priv/syslog.so
+install-erl-syslog: $(TARGETLIB)/$(EDEP)/syslog/priv/syslog_drv.so
 
 dialyzer: $(EPLT) master
 	$(DIALYZER) --get_warnings -Wunmatched_returns -Werror_handling --plt $(EPLT) -r $(EBIN)

--- a/lib/disco/cli.py
+++ b/lib/disco/cli.py
@@ -198,9 +198,10 @@ class Master(clx.server.Server):
         def lager_config(log_dir):
             return ['-lager', 'handlers',
                     ('[{lager_console_backend, info},'
-                     +'{lager_file_backend,'
-                     +' [{' + '"{0}/error.log"'.format(log_dir)   + ', error, 1048576000, "$D0", 5},'
-                     +'  {' + '"{0}/console.log"'.format(log_dir) + ', debug, 1048576000, "$D0", 5}]}]'),
+                     + '{lager_syslog_backend,'
+                     + ' ["disco", ' + '{0},'.format(settings['DISCO_LOG_FACILITY'])
+                     + ' {0}'.format(settings['DISCO_LOG_LEVEL'])
+                     + ']}]'),
                     '-lager', 'crash_log', '"{0}/crash.log"'.format(log_dir)]
         ret = (settings['DISCO_ERLANG'].split() +
                 lager_config(settings['DISCO_LOG_DIR']) +
@@ -212,6 +213,8 @@ class Master(clx.server.Server):
                  '-pa', epath('ebin'),
                  '-pa', edep('mochiweb'),
                  '-pa', edep('lager'),
+                 '-pa', edep('lager_syslog'),
+                 '-pa', edep('syslog'),
                  '-eval', 'application:start(disco)'])
         return ret
 

--- a/lib/disco/settings.py
+++ b/lib/disco/settings.py
@@ -87,6 +87,16 @@ Possible settings for Disco are as follows:
                 The same path is used for all nodes in the cluster.
                 Default is obtained using ``os.path.join(DISCO_ROOT, 'log')``.
 
+        .. envvar:: DISCO_LOG_FACILITY
+
+                Logging facility that disco uses.
+                Default is ``local7``.
+
+        .. envvar:: DISCO_LOG_LEVEL
+
+                Logging level that disco uses.
+                Default is ``info``.
+
         .. envvar:: DISCO_PID_DIR
 
                 Directory where pid-files are created.
@@ -275,6 +285,8 @@ class DiscoSettings(Settings):
         'DISCO_MASTER_CONFIG':   "os.path.join(DISCO_ROOT, '%s.config' % DISCO_NAME)",
         'DISCO_NAME':            "'disco_%s' % DISCO_PORT",
         'DISCO_LOG_DIR':         "os.path.join(DISCO_ROOT, 'log')",
+        'DISCO_LOG_FACILITY':    "'local7'",
+        'DISCO_LOG_LEVEL':       "'info'",
         'DISCO_PID_DIR':         "os.path.join(DISCO_ROOT, 'run')",
         'DISCO_PORT':            "8989",
         'DISCO_ROOT':            "os.path.join(DISCO_HOME, 'root')",

--- a/master/rebar.config
+++ b/master/rebar.config
@@ -1,8 +1,9 @@
 {erl_opts,
  [debug_info, warn_missing_spec, warnings_as_errors, {parse_transform, lager_transform}]}.
 {deps,
- [{lager, "1.0.0",
-   {git, "https://github.com/basho/lager.git", {tag, "1.0.0"}}},
+ [{lager, "(2.0|1.0|1.2).*",
+   {git, "https://github.com/basho/lager.git", {branch, "master"}}},
+  {lager_syslog, "",
+   {git, "git://github.com/basho/lager_syslog", {branch, "master"}}},
   {mochiweb, "",
    {git, "https://github.com/discoproject/mochiweb.git", {branch, "implement-max-conns"}}}]}.
-


### PR DESCRIPTION
Change logging over to allow for greater logging control via SYSLOG. Python settings have been changed as well as the rebar deps.

I'd be open to making a flag to have syslog-enabled an option instead of by default. We just had no need for it here if it was going to syslog.
