### PR TITLE
Issue 378: Use http/1.0 for retrieving blobs from ddfs.

### DIFF
--- a/master/src/worker_utils.erl
+++ b/master/src/worker_utils.erl
@@ -13,7 +13,8 @@ annotate_input({data, _} = I) ->
 annotate_input({dir, {Host, DirUrl, []}}) ->
     Url = disco:dir_to_url(DirUrl),
     Fetch = try
-                {ok, {_S, _H, Content}} = httpc:request(Url),
+                {ok, {_S, _H, Content}} = httpc:request(get, {Url, []},
+                    [{version, "HTTP/1.0"}], []),
                 {ok, Content}
             catch K:V ->
                     lager:error("Error (~p:~p) fetching ~p (~p): ~p",


### PR DESCRIPTION
There seems to be a bug in the erlang httpc client.  In certain cases, more than
one http request may be put on a single tcp connection.  When the server
responds to the http request, it closes the tcp connection and the http request
will be lost.
