### PR TITLE
Use the main mochiweb repository instead of the disco project fork.

### DIFF
--- a/master/rebar.config
+++ b/master/rebar.config
@@ -4,7 +4,7 @@
 [{lager, "2.0.*",
    {git, "https://github.com/basho/lager.git", {branch, "master"}}},
   {mochiweb, "",
-   {git, "https://github.com/discoproject/mochiweb.git", {branch, "discoproject"}}}]}.
+   {git, "https://github.com/mochi/mochiweb.git", {branch, "master"}}}]}.
 {xref_checks,
  % Remove 'exports_not_used' from default xref_checks since lager trips it.
  [undefined_function_calls]}.


### PR DESCRIPTION
The main repository has some bug fixes.  There does not seem to be any points in
maintaining a separate fork for mochiweb.
