### PR TITLE
Fix the Makefile to avoid running the dependency unittests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ otp_release:
   - R15B03
   - R15B02
   - R14B04
+  - R14B03
+  - R13B04

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,8 @@ xref: master
 	@ (cd master && ./rebar xref)
 
 test:
-	@ (cd master && ./rebar -C eunit.config get-deps eunit)
+	@ (cd master && ./rebar -C eunit.config clean get-deps compile &&\
+	./rebar -C eunit.config eunit skip_deps=true)
 
 contrib:
 	git submodule init


### PR DESCRIPTION
This lets us re-enable the builds for older versions of Erlang
without worrying about the failure of the tests of the dependencies.
