### PR TITLE
Do not use os realpath for non-symlink files.

### DIFF
--- a/lib/disco/fileutils.py
+++ b/lib/disco/fileutils.py
@@ -238,3 +238,6 @@ def files(path):
                 yield file
     else:
         yield path
+
+def get_valid_path(path):
+    return os.path.realpath(path) if os.path.islink(path) else path

--- a/lib/disco/settings.py
+++ b/lib/disco/settings.py
@@ -347,7 +347,8 @@ def guess_erlang():
 
 def guess_home():
     from disco.error import DiscoError
-    disco_lib  = os.path.dirname(os.path.realpath(__file__))
+    from disco.fileutils import get_valid_path
+    disco_lib  = os.path.dirname(get_valid_path(__file__))
     disco_home = os.path.dirname(os.path.dirname(disco_lib))
     if os.path.exists(os.path.join(disco_home, '.disco-home')):
         return disco_home

--- a/lib/disco/worker/modutil.py
+++ b/lib/disco/worker/modutil.py
@@ -185,7 +185,8 @@ def parse_function(function):
 def recurse_module(module, path):
     finder = modulefinder.ModuleFinder(path=list(user_paths()))
     finder.run_script(path)
-    return dict((name, os.path.realpath(module.__file__)) for name, module in finder.modules.items()
+    from disco.fileutils import get_valid_path
+    return dict((name, get_valid_path(module.__file__)) for name, module in finder.modules.items()
                 if name != '__main__' and module.__file__)
 
 def locate_modules(modules, recurse=True, include_sys=False):
@@ -210,7 +211,8 @@ def locate_modules(modules, recurse=True, include_sys=False):
 
     for module in modules:
         file, path, x = imp.find_module(module)
-        path = os.path.realpath(path)
+        from disco.fileutils import get_valid_path
+        path = get_valid_path(path)
 
         if dirname(path) in LOCALDIRS and os.path.isfile(path):
             found[module] = path


### PR DESCRIPTION
The python realpath will change the path to an absolute path if any
of the directories of the path is a simlink.  This results in not finding
these files in the user local directory and failing the test_modutil.
