### PR TITLE
Do not use proxy if no scheme is found for the item.

### DIFF
--- a/lib/disco/util.py
+++ b/lib/disco/util.py
@@ -281,7 +281,7 @@ def parse_dir(dir, label=None):
 
 def proxy_url(url, proxy=DiscoSettings()['DISCO_PROXY'], meth='GET', to_master=True):
     scheme, (host, port), path = urlsplit(url)
-    if proxy and scheme != "tag":
+    if proxy and scheme and scheme != "tag":
         if to_master:
             return '{0}/{1}'.format(proxy, path)
         return '{0}/proxy/{1}/{2}/{3}'.format(proxy, host, meth, path)


### PR DESCRIPTION
Proxies should not be used for accessing local files.
