### PR TITLE
Remove the KeyboardInterrupt from the parents of InterruptTest.

### DIFF
--- a/lib/disco/test.py
+++ b/lib/disco/test.py
@@ -22,7 +22,7 @@ ThreadingMixIn = socket_server.ThreadingMixIn
 OK = httplib.OK
 INTERNAL_SERVER_ERROR = httplib.INTERNAL_SERVER_ERROR
 
-class InterruptTest(KeyboardInterrupt, SkipTest):
+class InterruptTest(SkipTest):
     def __init__(self, test):
         super(InterruptTest, self).__init__("Test interrupted: May not have finished cleaning up")
         self.test = test


### PR DESCRIPTION
In the source code of python in Lib/unittest/case.py, before handling
the SkipTest exception, the KeyboardInterrupt exception is handled and
if we find the latter exception, it will be raised and the test is not
skipped.  I did not find any reasons for this hierarchy and have
dropped it.

With this commit, the test_sigint passes and we are now able to skip
tests with ctrl+c.
