### PR TITLE
Fixed output formatting of results and mapresults

### DIFF
--- a/bin/discocli.py
+++ b/bin/discocli.py
@@ -299,7 +299,7 @@ def stageresults(program, jobname):
     from disco.util import iterify
     stagename = program.options.stage
     for result in program.disco.stageresults(jobname, stagename):
-        print('\t'.join('{0}'.format((e,)) for e in iterify(result)).rstrip())
+        print('\t'.join('{0}'.format(e) for e in iterify(result)).rstrip())
 
 stageresults.add_option('-S', '--stage',
                         default='map',
@@ -366,7 +366,7 @@ def results(program, jobname):
     from disco.util import iterify
     status, results = program.disco.results(jobname)
     for result in results:
-        print('\t'.join('{0}'.format((e,)) for e in iterify(result)).rstrip())
+        print('\t'.join('{0}'.format(e) for e in iterify(result)).rstrip())
 
 @Disco.command
 def run(program, jobclass, *inputs):


### PR DESCRIPTION
In updating print statements to Python3 syntax (b7f08bc), some old-style string formatting was incorrectly translated resulting in a tuple being printed instead of a plain string. This affects the results and mapresults cli commands of disco.

This is similar to 1c5ffee which applied the same fix to the ddfs cli.
