### PR TITLE
Examples: Use threading to parallelize the production and consumption of...

### DIFF
--- a/bin/ddfscli.py
+++ b/bin/ddfscli.py
@@ -143,7 +143,7 @@ def chunk(program, tag, *urls):
                                     replicas=program.options.replicas,
                                     forceon=[] if not program.options.forceon else
                                         [program.options.forceon],
-                                    chunk_size = chunk_size,
+                                    chunk_size=chunk_size,
                                     max_record_size=max_record_size,
                                     update=program.options.update)
     for replicas in blobs:
@@ -157,7 +157,7 @@ chunk.add_option('-u', '--update',
                  action='store_true',
                  help='whether to perform an update or an append')
 chunk.add_option('-S', '--size',
-                 help='The size of the desired chunks in megabyte')
+                 help='The size of the desired chunks (in megabytes)')
 chunk.add_option('-Z', '--max-record-size',
                  help='The maximum permitted record size (in megabytes)')
 

--- a/lib/disco/ddfs.py
+++ b/lib/disco/ddfs.py
@@ -13,7 +13,7 @@ import os, re, random, json
 from disco.compat import StringIO, BytesIO, urlencode, basestring, bytes_to_str
 from disco.comm import upload, download, open_remote
 from disco.error import CommError
-from disco.fileutils import Chunker, CHUNK_SIZE
+from disco.fileutils import Chunker, CHUNK_SIZE, MAX_RECORD_SIZE
 from disco.settings import DiscoSettings
 from disco.util import isiterable, iterify, listify, partition
 from disco.util import urljoin, urlsplit, urlresolve, urltoken, proxy_url
@@ -126,6 +126,7 @@ class DDFS(object):
               update=False,
               token=None,
               chunk_size=CHUNK_SIZE,
+              max_record_size=MAX_RECORD_SIZE,
               **kwargs):
         """
         Chunks the contents of `urls`,
@@ -137,7 +138,8 @@ class DDFS(object):
             kwargs['reader'] = None
 
         def chunk_iter(replicas):
-            chunker = Chunker(chunk_size=chunk_size)
+            chunker = Chunker(chunk_size=chunk_size,
+                    max_record_size=max_record_size)
             return chunker.chunks(classic_iterator([replicas], **kwargs))
 
         def chunk_name(replicas, n):

--- a/lib/disco/fileutils.py
+++ b/lib/disco/fileutils.py
@@ -112,7 +112,8 @@ class DiscoOutputStream_v1(object):
     def hunk_write(self, data):
         size = len(data)
         if self.max_record_size and size > self.max_record_size:
-            raise ValueError("Record too big to write to hunk")
+            raise ValueError("Record of size " + str(size) +
+                             " is larger than max_record_size: " + str(self.max_record_size))
         self.hunk.write(data)
         self.hunk_size += size
 

--- a/lib/disco/fileutils.py
+++ b/lib/disco/fileutils.py
@@ -31,8 +31,9 @@ class Chunker(object):
       a new hunk is added with size ((H - 1) + (R - 1)) * S
       sizoof(chunk) = C - 1 + ((H - 1) + (R - 1)) * S + len(header)
     """
-    def __init__(self, chunk_size=CHUNK_SIZE):
+    def __init__(self, chunk_size=CHUNK_SIZE, max_record_size=MAX_RECORD_SIZE):
         self.chunk_size = chunk_size
+        self.max_record_size = max_record_size
 
     def chunks(self, records):
         out = self.makeout()
@@ -49,7 +50,7 @@ class Chunker(object):
         return out.stream.getvalue()
 
     def makeout(self):
-        return DiscoOutputStream(BytesIO(), max_record_size=MAX_RECORD_SIZE)
+        return DiscoOutputStream(BytesIO(), max_record_size=self.max_record_size)
 
 class DiscoOutputStream_v0(object):
     def __init__(self, stream):


### PR DESCRIPTION
... text in xml_reader.
