### PR TITLE
erlang refactor: Add type information to the data structures.

### DIFF
--- a/master/include/common_types.hrl
+++ b/master/include/common_types.hrl
@@ -4,3 +4,17 @@
 
 % The host portion of a url, if available.
 -type url_host() :: host() | none.
+
+-type seq_id() :: non_neg_integer().
+
+-ifdef(namespaced_types).
+-type disco_dict(K,V) :: dict:dict(K,V).
+-type disco_gbtree(K, V) :: gb_trees:tree(K, V).
+-type disco_gbset(K) :: gb_sets:set(K).
+-type disco_queue(K) :: queue:queue(K).
+-else.
+-type disco_dict(_K,_V) :: dict().
+-type disco_gbtree(_K,_V) :: gb_tree().
+-type disco_gbset(_K) :: gb_set().
+-type disco_queue(_K) :: queue().
+-endif.

--- a/master/include/disco.hrl
+++ b/master/include/disco.hrl
@@ -15,7 +15,8 @@
 % types used for local-cluster mode
 
 %                          {NextPort, {host() -> {GetPort, PutPort}}}.
--type port_map() :: none | {non_neg_integer(), gb_tree()}.
+-type port_map() :: none |
+                {non_neg_integer(), disco_gbtree(host(), {non_neg_integer(), non_neg_integer()})}.
 
 -record(node_ports, {get_port :: non_neg_integer(),
                      put_port :: non_neg_integer()}).

--- a/master/include/fair_scheduler.hrl
+++ b/master/include/fair_scheduler.hrl
@@ -1,7 +1,7 @@
 % Utility types.
 
 -type next_job() :: {ok, pid()} | nojobs.
--type loadstats() :: gb_tree(). % host() -> non_neg_integer() (# running tasks)
+-type loadstats() :: disco_gbtree(host(), non_neg_integer()). % #running tasks
 -type priority() :: float().
 -type node_info() :: {host(), cores(), non_neg_integer()}.
 

--- a/master/include/job_coordinator.hrl
+++ b/master/include/job_coordinator.hrl
@@ -18,13 +18,13 @@
                     depends = []        :: [task_id()],
                     % Failure statistics.
                     failed_count = 0               :: non_neg_integer(),
-                    failed_hosts = gb_sets:empty() :: gb_set()}).
+                    failed_hosts = gb_sets:empty() :: disco_gbset(host())}).
 -type task_info() :: #task_info{}.
 -record(data_info, {source   :: data_input(),
                     % host() -> data_input() ; where additional copies can be found
-                    locations = gb_trees:empty() :: gb_tree(),
+                    locations = gb_trees:empty() :: disco_gbtree(host(), data_input()),
                     % data location host() -> non_neg_integer()
-                    failures  = gb_trees:empty() :: gb_tree()}).
+                    failures  = gb_trees:empty() :: disco_gbtree(host(), non_neg_integer())}).
 -type data_info() :: #data_info{}.
 
 % Maximum number of failures to record for intermediate data before

--- a/master/include/pipeline.hrl
+++ b/master/include/pipeline.hrl
@@ -109,7 +109,7 @@
 % host-allocator.
 -record(task_run, {runid         :: task_run_id(),
                    host          :: url_host(),
-                   failed_hosts  :: gb_set(),
+                   failed_hosts  :: disco_gbset(host()),
                    input         :: [{input_id(), data_input()}]}).
 -type task_run() :: #task_run{}.
 

--- a/master/rebar.config
+++ b/master/rebar.config
@@ -1,6 +1,8 @@
 {erl_opts,
  [debug_info, warn_missing_spec, warnings_as_errors, nowarn_deprecated_type,
-{parse_transform, lager_transform}]}.
+  {parse_transform, lager_transform},
+  {platform_define, "^[0-9]+", namespaced_types}
+]}.
 {deps,
 [{lager, "2.0.3",
    {git, "https://github.com/basho/lager.git", {tag, "2.0.3"}}},

--- a/master/src/ddfs/ddfs_master.erl
+++ b/master/src/ddfs/ddfs_master.erl
@@ -36,15 +36,15 @@
 -type node_info() :: {node(), {non_neg_integer(), non_neg_integer()}}.
 -type gc_stats() :: none | gc_run_stats().
 
--record(state, {tags      = gb_trees:empty()          :: gb_tree(),
-                tag_cache = {false, gb_sets:empty()}  :: {boolean(), gb_set()},
+-record(state, {tags      = gb_trees:empty()          :: disco_gbtree(tagname(),pid()),
+                tag_cache = {false, gb_sets:empty()}  :: {boolean(), disco_gbset(tagname())},
                 cache_refresher                       :: pid(),
 
                 nodes             = []                :: [node_info()],
                 write_blacklist   = []                :: [node()],
                 read_blacklist    = []                :: [node()],
                 gc_blacklist      = []                :: [node()],
-                safe_gc_blacklist = gb_sets:empty()   :: gb_set(),
+                safe_gc_blacklist = gb_sets:empty()   :: disco_gbset(tagname()),
                 gc_stats          = none              :: none | {gc_stats(), erlang:timestamp()}}).
 -type state() :: #state{}.
 -type replyto() :: {pid(), reference()}.
@@ -130,7 +130,7 @@ new_blob(Master, Obj, K, Include, Exclude) ->
 safe_gc_blacklist() ->
     gen_server:call(?MODULE, safe_gc_blacklist).
 
--spec safe_gc_blacklist(gb_set()) -> ok.
+-spec safe_gc_blacklist(disco_gbset(tagname())) -> ok.
 safe_gc_blacklist(SafeGCBlacklist) ->
     gen_server:cast(?MODULE, {safe_gc_blacklist, SafeGCBlacklist}).
 
@@ -143,11 +143,11 @@ update_gc_stats(Stats) ->
 update_nodes(DDFSNodes) ->
     gen_server:cast(?MODULE, {update_nodes, DDFSNodes}).
 
--spec update_nodestats(gb_tree()) -> ok.
+-spec update_nodestats(disco_gbtree(tagname(),pid())) -> ok.
 update_nodestats(NewNodes) ->
     gen_server:cast(?MODULE, {update_nodestats, NewNodes}).
 
--spec update_tag_cache(gb_set()) -> ok.
+-spec update_tag_cache(disco_gbset(tagname())) -> ok.
 update_tag_cache(TagCache) ->
     gen_server:cast(?MODULE, {update_tag_cache, TagCache}).
 
@@ -240,12 +240,12 @@ handle_call(safe_gc_blacklist, _From, #state{safe_gc_blacklist = SBL} = S) ->
 
 -spec handle_cast({tag_notify, ddfs_tag:cast_msg(), tagname()}
                   | {gc_blacklist, [node()]}
-                  | {safe_gc_blacklist, gb_set()}
+                  | {safe_gc_blacklist, disco_gbset(tagname())}
                   | {update_gc_stats, gc_stats()}
-                  | {update_tag_cache, gb_set()}
+                  | {update_tag_cache, disco_gbset(tagname())}
                   | refresh_tag_cache
                   | {update_nodes, nodes_update()}
-                  | {update_nodestats, gb_tree()},
+                  | {update_nodestats, disco_gbtree(tagname(),pid())},
                   state()) -> gs_noreply().
 handle_cast({tag_notify, M, Tag}, S) ->
     {noreply, do_tag_notify(M, Tag, S)};
@@ -353,8 +353,9 @@ do_new_blob(Obj, K, Include, Exclude, BlackList, Nodes) ->
 % Tag request: Start a new tag server if one doesn't exist already. Forward
 % the request to the tag server.
 
--spec get_tag_pid(tagname(), gb_tree(), {boolean(), gb_set()}) ->
-                         {pid(), gb_tree()}.
+-spec get_tag_pid(tagname(), disco_gbtree(tagname(),pid()), {boolean(),
+                  disco_gbset(tagname())}) ->
+    {pid(), disco_gbtree(tagname(), pid())}.
 get_tag_pid(Tag, Tags, {Valid, Cache}) ->
     case gb_trees:lookup(Tag, Tags) of
         none ->
@@ -417,7 +418,7 @@ do_update_nodes(NewNodes, #state{nodes = Nodes, tags = Tags} = S) ->
                     read_blacklist = ReadBlacklist}
     end.
 
--spec do_update_nodestats(gb_tree(), state()) -> state().
+-spec do_update_nodestats(disco_gbtree(tagname(),pid()), state()) -> state().
 do_update_nodestats(NewNodes, #state{nodes = Nodes} = S) ->
     UpdatedNodes = [case gb_trees:lookup(Node, NewNodes) of
                         none ->

--- a/master/src/ddfs/ddfs_node.erl
+++ b/master/src/ddfs/ddfs_node.erl
@@ -12,12 +12,14 @@
 -include("ddfs.hrl").
 -include("ddfs_tag.hrl").
 
+-type tag_map() :: disco_gbtree(binary(), {erlang:timestamp(), volume_name()}).
+
 -record(state, {nodename :: host(),
                 root :: path(),
                 vols :: [volume()],
                 putq :: http_queue:q(),
                 getq :: http_queue:q(),
-                tags :: gb_tree(),
+                tags :: tag_map(),
                 scanner :: pid()}).
 -type state() :: #state{}.
 
@@ -168,7 +170,7 @@ handle_call({put_tag_commit, Tag, TagVol}, _, S) ->
 
 -type casts() :: rescan_tags
                | {update_vols, [volume()]}
-               | {update_tags, gb_tree()}.
+               | {update_tags, tag_map()}.
 -spec handle_cast(casts(), state()) -> gs_noreply().
 handle_cast(rescan_tags, #state{scanner = Scanner} = S) ->
     Scanner ! rescan,
@@ -364,7 +366,7 @@ find_vols(Root) ->
             Error
     end.
 
--spec find_tags(path(), [volume()]) -> {ok, gb_tree()}.
+-spec find_tags(path(), [volume()]) -> {ok, tag_map()}.
 find_tags(Root, Vols) ->
     {ok,
      lists:foldl(fun({_Space, VolName}, Tags) ->
@@ -374,7 +376,7 @@ find_tags(Root, Vols) ->
                                               end, Tags)
                  end, gb_trees:empty(), Vols)}.
 
--spec parse_tag(nonempty_string(), volume_name(), gb_tree()) -> gb_tree().
+-spec parse_tag(nonempty_string(), volume_name(), tag_map()) -> tag_map().
 parse_tag("!" ++ _, _, Tags) -> Tags;
 parse_tag(Tag, VolName, Tags) ->
     {TagName, Time} = ddfs_util:unpack_objname(Tag),

--- a/master/src/ddfs/ddfs_tag.erl
+++ b/master/src/ddfs/ddfs_tag.erl
@@ -13,6 +13,7 @@
          handle_info/2, terminate/2, code_change/3]).
 
 -type replyto() :: {pid(), reference()}.
+-type term_map() :: disco_gbtree(term(), {[replyto()], [[url()]]}).
 
 -record(state, {tag  :: tagname(),
                 data :: none |
@@ -22,10 +23,10 @@
                         {ok, tagcontent()},
                 ddfs_data :: path(),
                 timeout :: non_neg_integer(),
-                delayed   = false :: false | gb_tree(),
+                delayed   = false :: false | term_map(),
                 replicas  = false :: false | [node()],
                 locations = false :: false | [url()],
-                url_cache = false :: false | gb_set()}).
+                url_cache = false :: false | disco_gbset(tagname())}).
 -type state() :: #state{}.
 
 % API messages.
@@ -454,7 +455,7 @@ do_gc_rr_update(#state{tag = TagName, data = {ok, D} = Tag} = S,
             S
     end.
 
--spec gc_update_urls(tagid(), [[url()]], gb_tree(), [node()], tagid())
+-spec gc_update_urls(tagid(), [[url()]], term_map(), [node()], tagid())
                     -> [[url()]].
 gc_update_urls(Id, OldUrls, Map, Blacklist, UpdateId) ->
     gc_update_urls(Id, OldUrls, Map, Blacklist, UpdateId, []).
@@ -576,7 +577,7 @@ read_tagdata(TagID, Locations, Replicas, Failed, _Error) ->
             read_tagdata(TagID, Locations, Replicas, [Chosen|Failed], E)
     end.
 
--spec do_delayed_update([[url()]], [term()], replyto(), gb_tree(), state())
+-spec do_delayed_update([[url()]], [term()], replyto(), term_map(), state())
                        -> state().
 do_delayed_update(Urls, Opt, ReplyTo, Buffer, S) ->
     % We must handle updates with different set of options separately.

--- a/master/src/disco_server.erl
+++ b/master/src/disco_server.erl
@@ -29,9 +29,9 @@
                 stats_crashed :: non_neg_integer()}).
 -type dnode() :: #dnode{}.
 
--record(state, {workers = gb_trees:empty() :: gb_tree(), % pid()    -> {host(), task()}
-                nodes   = gb_trees:empty() :: gb_tree(), % host()   -> dnode()
-                purged  = gb_trees:empty() :: gb_tree(), % binary() -> timestamp()
+-record(state, {workers = gb_trees:empty() :: disco_gbtree(pid(), {host(), task()}),
+        nodes   = gb_trees:empty() :: disco_gbtree(host(), dnode()),
+        purged  = gb_trees:empty() :: disco_gbtree(binary(), erlang:timestamp()),
                 jobpack_queue :: pid(),
 
                 % The below are only used in cluster-in-a-box mode.
@@ -312,7 +312,7 @@ allow_read(#dnode{}) ->
 -spec allow_task(dnode()) -> boolean().
 allow_task(#dnode{} = N) -> allow_write(N).
 
--spec update_nodes(gb_tree()) -> ok.
+-spec update_nodes(disco_gbtree(host(), dnode())) -> ok.
 update_nodes(Nodes) ->
     WhiteNodes = [{H, S, R}
                   || #dnode{host = H, slots = S, num_running = R}

--- a/master/src/event_server.erl
+++ b/master/src/event_server.erl
@@ -46,9 +46,9 @@
                           Status  :: job_status(),
                           JobInfo :: none | jobinfo(),
                           Results :: [[url()]],
-                          Count   :: dict(),
-                          Ready   :: dict(),
-                          Failed  :: dict()}.
+                          Count   :: stage_dict(),
+                          Ready   :: stage_dict(),
+                          Failed  :: stage_dict()}.
 
 -export_type([event/0, task_info/0, task_msg/0, job_eventinfo/0]).
 
@@ -165,9 +165,12 @@ start_link() ->
     end.
 
 % events dict: jobname -> job_ent()
+-type event_dict() :: disco_dict(jobname(), job_ent()).
 % msgbuf dict: jobname -> { <nmsgs>, <list-length>, [<msg>] }
--record(state, {events = dict:new() :: dict(),
-                msgbuf = dict:new() :: dict(),
+-type job_msg_dict() :: disco_dict(jobname(), {non_neg_integer(), non_neg_integer(), [binary()]}).
+
+-record(state, {events = dict:new() :: event_dict(),
+                msgbuf = dict:new() :: job_msg_dict(),
                 hosts  = []         :: [host()]}).
 -type state() :: #state{}.
 
@@ -235,13 +238,16 @@ code_change(_OldVsn, State, _Extra) -> {ok, State}.
 
 % State management.
 
+-type stage_dict() :: disco_dict(stage_name(), non_neg_integer()).
+-type stage_result_dict() :: disco_dict(stage_name(), [[url()]]).
+
 -record(job_ent, {job_coord :: pid(),
                   start     :: erlang:timestamp(),
                   job_data    = none :: none | jobinfo(),
-                  task_count         :: dict(), % stage_name() -> count
-                  task_ready         :: dict(), % stage_name() -> count
-                  task_failed        :: dict(), % stage_name() -> count
-                  stage_results      :: dict(), % stage_name() -> results
+                  task_count         :: stage_dict(),
+                  task_ready         :: stage_dict(),
+                  task_failed        :: stage_dict(),
+                  stage_results      :: stage_result_dict(),
                   job_results = none :: none | [url() | [url()]]}).
 -type job_ent() :: #job_ent{}.
 
@@ -281,14 +287,14 @@ job_status(_JE) ->
 
 % Server implemention.
 
--spec do_get_jobs(dict()) -> {ok, [joblist_entry()]}.
+-spec do_get_jobs(event_dict()) -> {ok, [joblist_entry()]}.
 do_get_jobs(Events) ->
     Jobs = dict:fold(fun (Name, #job_ent{start = Start} = JobEnt, Acc) ->
                              [{Name, job_status(JobEnt), Start}|Acc]
                      end, [], Events),
     {ok, Jobs}.
 
--spec do_get_job_msgs(jobname(), string(), integer(), dict()) -> {ok, [binary()]}.
+-spec do_get_job_msgs(jobname(), string(), integer(), job_msg_dict()) -> {ok, [binary()]}.
 do_get_job_msgs(JobName, Query, N0, MsgBuf) ->
     N = if
             N0 > 1000 -> 1000;
@@ -303,7 +309,7 @@ do_get_job_msgs(JobName, Query, N0, MsgBuf) ->
             {ok, json_list(tail_log(JobName, N))}
     end.
 
--spec do_get_results(jobname(), dict())
+-spec do_get_results(jobname(), event_dict())
                     -> invalid_job | {job_status(), pid()}
                            | {ready, pid(), [url() | [url()]]}.
 do_get_results(JobName, Events) ->
@@ -316,7 +322,7 @@ do_get_results(JobName, Events) ->
             {job_status(JE), Pid}
     end.
 
--spec do_get_stage_results(jobname(), stage_name(), dict())
+-spec do_get_stage_results(jobname(), stage_name(), event_dict())
                         -> invalid_job | not_ready
                                | {ok, [[url()]]}.
 do_get_stage_results(JobName, StageName, Events) ->
@@ -330,7 +336,7 @@ do_get_stage_results(JobName, StageName, Events) ->
             end
     end.
 
--spec do_get_jobinfo(jobname(), dict()) -> invalid_job | {ok, job_eventinfo()}.
+-spec do_get_jobinfo(jobname(), event_dict()) -> invalid_job | {ok, job_eventinfo()}.
 do_get_jobinfo(JobName, Events) ->
     case dict:find(JobName, Events) of
         error ->
@@ -450,7 +456,7 @@ json_list([X], L) ->
 json_list([X|R], L) ->
     json_list(R, [<<X/binary, ",">>|L]).
 
--spec unique_key(jobname(), dict()) -> invalid_prefix | {ok, jobname()}.
+-spec unique_key(jobname(), event_dict()) -> invalid_prefix | {ok, jobname()}.
 unique_key(Prefix, Dict) ->
     C = string:chr(Prefix, $/) + string:chr(Prefix, $.),
     if C > 0 ->

--- a/master/src/fair_scheduler_fair_policy.erl
+++ b/master/src/fair_scheduler_fair_policy.erl
@@ -28,7 +28,9 @@
 
 -type prioq_item() :: {priority(), pid(), jobname()}.
 -type prioq() :: [prioq_item()].
--type state() :: {gb_tree(), prioq(), cores()}.
+-type job_map() :: disco_gbtree(pid(), job()).
+-type state() :: {job_map(), prioq(), cores()}.
+
 
 -spec start_link() -> {ok, pid()}.
 start_link() ->
@@ -85,7 +87,7 @@ handle_cast({new_job, JobPid, JobName}, {Jobs, PrioQ, NC}) ->
                          gs_reply([{jobname(), priority()}]);
                  (dbg_state_msg(), from(), state()) -> gs_reply(state());
                  (next_job_msg(), from(), state()) -> gs_reply(next_job());
-                 (priv_get_jobs, from(), state()) -> gs_reply(gb_tree()).
+                 (priv_get_jobs, from(), state()) -> gs_reply(job_map()).
 
 % Return current priorities for the ui
 handle_call(current_priorities, _, {_, PrioQ, _} = S) ->
@@ -130,8 +132,8 @@ dropwhile([{_, JobPid, _} = E|R], H, NotJobs) ->
 % the job actually starts a new task (1 / NumCores increase in its share)
 % which might not be always true. Fairness fairy will eventually fix the
 % bias.
--spec bias_priority(job(), prioq(), gb_tree(), non_neg_integer())
-                   -> {gb_tree(), prioq()}.
+-spec bias_priority(job(), prioq(), job_map(), non_neg_integer())
+                   -> {job_map(), prioq()}.
 bias_priority(#job{name = N, pid = JobPid, bias = OldBias, prio = OldPrio} = Job,
               PrioQ, Jobs, NumCores) ->
     Bias = OldBias + 1 / NumCores,

--- a/master/src/fair_scheduler_fifo_policy.erl
+++ b/master/src/fair_scheduler_fifo_policy.erl
@@ -17,7 +17,7 @@
 -export([start_link/0, init/1, handle_call/3, handle_cast/2,
          handle_info/2, terminate/2, code_change/3]).
 
--type state() :: queue().
+-type state() :: disco_queue({pid(), jobname()}).
 
 -spec start_link() -> {ok, pid()}.
 start_link() ->

--- a/master/src/fair_scheduler_job.erl
+++ b/master/src/fair_scheduler_job.erl
@@ -95,14 +95,17 @@ schedule(Mode, Job, Jobs, AvailableNodes) ->
 %% ===================================================================
 %% gen_server callbacks
 
+-type pid_map() :: disco_gbtree(pid(), host()).
+% url_host() -> {#queued, #run, [task()]}
+-type task_map() :: disco_gbtree(url_host(), {non_neg_integer(),
+                                              non_neg_integer(), [task()]}).
+-type host_set() :: disco_gbset(url_host()).
+
 -record(state, {job_name    :: jobname(),
                 job_coord   :: pid(),
-                % url_host() -> {#queued, #run, [task()]}
-                host_queue = gb_trees:empty() :: gb_tree(),
-                % pid() -> host()
-                running    = gb_trees:empty() :: gb_tree(),
-                % [host()]
-                cluster    = gb_sets:empty() :: gb_set()}).
+                host_queue = gb_trees:empty() :: task_map(),
+                running    = gb_trees:empty() :: pid_map(),
+                cluster    = gb_sets:empty() :: host_set()}).
 -type state() :: #state{}.
 
 -spec init({jobname(), pid()}) -> gs_init() | {stop, normal}.
@@ -219,7 +222,7 @@ code_change(_OldVsn, State, _Extra) -> {ok, State}.
 
 %% ===================================================================
 %% Internal utilities.
--spec get_default(node(), gb_tree(), T) -> T.
+-spec get_default(node(), disco_gbtree(node(), T), T) -> T.
 get_default(Key, Tree, Default) ->
     case gb_trees:lookup(Key, Tree) of
         none -> Default;
@@ -241,7 +244,7 @@ all_empty_nodes([Job|Jobs], AvailableNodes) ->
             all_empty_nodes(Jobs, AvailableNodes)
     end.
 
--spec schedule_local(gb_tree(), [node()]) -> {schedule_result(), gb_tree()}.
+-spec schedule_local(task_map(), [node()]) -> {schedule_result(), task_map()}.
 schedule_local(Tasks, AvailableNodes) ->
     % Does the job have any local tasks to be run on AvailableNodes?
     case datalocal_nodes(Tasks, AvailableNodes) of
@@ -267,8 +270,8 @@ schedule_local(Tasks, AvailableNodes) ->
             {{run, Node, Task}, gb_trees:update(Node, {N - 1, C, R}, Tasks)}
     end.
 
--spec pop_and_switch_node(gb_tree(), [none|host()], [host()])
-                         -> {schedule_result(), gb_tree()}.
+-spec pop_and_switch_node(task_map(), [none|host()], [host()])
+                         -> {schedule_result(), task_map()}.
 pop_and_switch_node(Tasks, _, []) -> {nonodes, Tasks};
 pop_and_switch_node(Tasks, Nodes, AvailableNodes) ->
     case pop_busiest_node(Tasks, Nodes) of
@@ -290,7 +293,7 @@ pop_and_switch_node(Tasks, Nodes, AvailableNodes) ->
 
 % pop_busiest_node defines the policy for choosing the next task from a chosen
 % set of Nodes. Pick the task from the longest list.
--spec pop_busiest_node(gb_tree(), [host()]) -> {schedule_result(), gb_tree()}.
+-spec pop_busiest_node(task_map(), [host()]) -> {schedule_result(), task_map()}.
 pop_busiest_node(Tasks, []) -> {nonodes, Tasks};
 pop_busiest_node(Tasks, Nodes) ->
     {{N, C, [Task|R]}, MaxNode} = lists:max([{gb_trees:get(Node, Tasks), Node}
@@ -314,7 +317,7 @@ choose_host({#task_spec{}, #task_run{host = Host}}, AvailableHosts) ->
     end.
 
 % Pop the first task in Nodes that can be run
--spec pop_suitable(gb_tree(), [host()], [host()]) -> {schedule_result(), gb_tree()}.
+-spec pop_suitable(task_map(), [host()], [host()]) -> {schedule_result(), task_map()}.
 pop_suitable(Tasks, Nodes, AvailableNodes) ->
     case find_suitable([], none, Nodes, Tasks, AvailableNodes) of
         false -> {nonodes, Tasks};
@@ -326,7 +329,7 @@ pop_suitable(Tasks, Nodes, AvailableNodes) ->
 
 % Find first task from any node in Nodes that can be run,
 % i.e. choose_node() =/= false
--spec find_suitable([task()], none|host(), [host()], gb_tree(), [host()]) ->
+-spec find_suitable([task()], none|host(), [host()], task_map(), [host()]) ->
     {ok, task(), host(), host()} | false.
 find_suitable([], _, [], _, _) -> false;
 find_suitable([], _, [Node|R], Tasks, AvailableNodes) ->
@@ -339,16 +342,16 @@ find_suitable([T|R], Node, RestNodes, Tasks, AvailableNodes) ->
     end.
 
 % return nodes that don't have any local tasks assigned to them
--spec empty_nodes(gb_tree(), [host()]) -> [host()].
+-spec empty_nodes(task_map(), [host()]) -> [host()].
 empty_nodes(Tasks, AvailableNodes) ->
     filter_nodes(Tasks, AvailableNodes, false).
 
 % return nodes that have at least one local task assigned to them
--spec datalocal_nodes(gb_tree(), [host()]) -> [host()].
+-spec datalocal_nodes(task_map(), [host()]) -> [host()].
 datalocal_nodes(Tasks, AvailableNodes) ->
     filter_nodes(Tasks, AvailableNodes, true).
 
--spec filter_nodes(gb_tree(), [host()], boolean()) -> [host()].
+-spec filter_nodes(task_map(), [host()], boolean()) -> [host()].
 filter_nodes(Tasks, AvailableNodes, Local) ->
     [Node || Node <- AvailableNodes,
              case gb_trees:lookup(Node, Tasks) of
@@ -360,7 +363,7 @@ filter_nodes(Tasks, AvailableNodes, Local) ->
 %% ===================================================================
 %% Host assignment for a new runnable task.
 
--spec assign_task(pid(), task(), loadstats(), gb_tree(), gb_set()) -> gb_tree().
+-spec assign_task(pid(), task(), loadstats(), task_map(), host_set()) -> task_map().
 assign_task(JC, {#task_spec{taskid = TaskId}, #task_run{host = Host}} = T,
             _LoadStats, HQ, Cluster)
   when Host =/= none ->
@@ -404,7 +407,7 @@ assign_task(JC, {TS, #task_run{failed_hosts = Blacklist, input = Inputs} = TR} =
             gb_trees:enter(Host, {N + 1, Count + 1, [T|Tasks]}, HQ)
     end.
 
--spec best_host(gb_set(), [{input_id(), data_input()}]) -> url_host().
+-spec best_host(host_set(), [{input_id(), data_input()}]) -> url_host().
 best_host(HostCandidates, Inputs) ->
     ByLocality = lists:flatten([pipeline_utils:ranked_locations(I)
                                 || {_Id, I} <- Inputs]),
@@ -418,7 +421,7 @@ best_host(HostCandidates, Inputs) ->
 
 % The cluster topology might have changed, with new hosts appearing or
 % existing ones removed.
--spec reassign_tasks(pid(), gb_tree(), loadstats(), gb_set()) -> gb_tree().
+-spec reassign_tasks(pid(), task_map(), loadstats(), host_set()) -> task_map().
 reassign_tasks(JC, HQ, LoadStats, Cluster) ->
     {OHQ, NHQ} =
         lists:foldl(

--- a/master/src/job_coordinator.erl
+++ b/master/src/job_coordinator.erl
@@ -112,13 +112,13 @@ stage_done(Stage) ->
                 next_runid  = 0  :: task_run_id(),
                 input_pid = none :: none | pid(),
                 % cluster membership: [host()]
-                hosts      = gb_sets:empty()  :: gb_set(),
+                hosts      = gb_sets:empty()  :: disco_gbset(host()),
                 % input | task_id() -> task_info().
-                tasks      = gb_trees:empty() :: gb_tree(),
+                tasks      = gb_trees:empty() :: disco_gbtree(task_id(), task_info()),
                 % input_id() -> data_info().
-                data_map   = gb_trees:empty() :: gb_tree(),
+                data_map   = gb_trees:empty() :: disco_gbtree(input_id(), data_info()),
                 % stage_name() -> stage_info().
-                stage_info = gb_trees:empty() :: gb_tree()}).
+                stage_info = gb_trees:empty() :: disco_gbtree(stage_name(), stage_info())}).
 -type state() :: #state{}.
 
 -spec init({pid(), binary()}) -> gs_init() | {stop, term()}.
@@ -614,7 +614,7 @@ do_submit_tasks(Mode, [TaskId | Rest], #state{stage_info = SI,
 
 % This returns the list of runnable dependency tasks, and an updated
 % state.
--spec collect_runnable_deps(task_id(), gb_set(), state())
+-spec collect_runnable_deps(task_id(), disco_gbset(host()), state())
                            -> {[task_id()], state()}.
 collect_runnable_deps(TaskId, FHosts, #state{tasks      = Tasks,
                                              stage_info = SI,

--- a/master/src/jobpack.erl
+++ b/master/src/jobpack.erl
@@ -33,19 +33,20 @@ grouping(G) ->
     throw({error, disco:format("invalid grouping '~p'", [G])}).
 
 % Lookup utilities.
+-type job_dict() :: disco_dict(binary(), term()).
 
--spec dict({struct, [{term(), term()}]}) -> dict().
+-spec dict({struct, [{term(), term()}]}) -> job_dict().
 dict({struct, List}) ->
     dict:from_list(List).
 
--spec find(binary(), dict()) -> term().
+-spec find(binary(), job_dict()) -> term().
 find(Key, Dict) ->
     case dict:find(Key, Dict) of
         {ok, Field} -> Field;
         error -> throw({error, disco:format("jobpack missing key '~s'", [Key])})
     end.
 
--spec find(binary(), dict(), T) -> T.
+-spec find(binary(), job_dict(), T) -> T.
 find(Key, Dict, Default) ->
     case dict:find(Key, Dict) of
         {ok, Field} -> Field;
@@ -61,7 +62,7 @@ jobinfo(JobPack) ->
     VersionInfo = version_info(Version, JobDict),
     {Prefix, fixup_versions(JobInfo, VersionInfo)}.
 
--spec jobdict(jobpack()) -> {non_neg_integer(), dict()}.
+-spec jobdict(jobpack()) -> {non_neg_integer(), job_dict()}.
 jobdict(<<?MAGIC:16/big,
           Version:16/big,
           JobDictOffset:32/big,
@@ -71,7 +72,7 @@ jobdict(<<?MAGIC:16/big,
     <<_:JobDictOffset/bytes, JobDict:JobDictLength/bytes, _/binary>> = JobPack,
     {Version, dict(mochijson2:decode(JobDict))}.
 
--spec core_jobinfo(jobpack(), dict()) -> {jobname(), jobinfo()}.
+-spec core_jobinfo(jobpack(), job_dict()) -> {jobname(), jobinfo()}.
 core_jobinfo(JobPack, JobDict) ->
     Prefix  = find(<<"prefix">>, JobDict),
     SaveResults = find(<<"save_results">>, JobDict, false),
@@ -120,7 +121,7 @@ jobzip(<<?MAGIC:16/big,
                     schedule     = none  :: task_schedule(),
                     inputs       = []    :: [data_input()]}).
 
--spec version_info(non_neg_integer(), dict()) -> #ver1_info{} | #ver2_info{}.
+-spec version_info(non_neg_integer(), job_dict()) -> #ver1_info{} | #ver2_info{}.
 version_info(?VERSION_1, JobDict) ->
     Scheduler = dict(find(<<"scheduler">>, JobDict)),
     #ver1_info{inputs = find(<<"input">>, JobDict),

--- a/master/src/lock_server.erl
+++ b/master/src/lock_server.erl
@@ -2,6 +2,7 @@
 -behaviour(gen_server).
 
 -include("gs_util.hrl").
+-include("common_types.hrl").
 
 -export([start_link/0, lock/3]).
 -export([init/1,
@@ -14,8 +15,8 @@
 -define(PROC_TIMEOUT, 10 * 60 * 1000).
 
 -type lockname() :: nonempty_string().
--record(state, {waiters :: gb_tree(),
-                procs   :: gb_tree()}).
+-record(state, {waiters :: disco_gbtree(lockname(), [lockname()]),
+        procs   :: disco_gbtree(pid(), {pid(), term()})}).
 -type state() :: #state{}.
 
 -spec start_link() -> no_return().

--- a/master/src/pipeline_utils.erl
+++ b/master/src/pipeline_utils.erl
@@ -71,7 +71,6 @@ next_stage([_S|Rest], S) -> next_stage(Rest, S).
 
 % utility to create a group -> [dir_spec()] mapping for the dir files
 % in the specified outputs.
--spec dirdict([{task_id(), [task_output()]}]) -> dict().
 dirdict(Outputs) ->
     Dirs = [{{L, H}, {{Tid, Outid}, D}}
             || {Tid, Tout} <- Outputs,

--- a/master/src/temp_gc.erl
+++ b/master/src/temp_gc.erl
@@ -55,7 +55,7 @@ ddfs_delete(Tag) ->
 get_purged() ->
     disco_server:get_purged(get(master)).
 
--spec process_dir(path(), [path()], gb_set(), gb_set()) -> ok.
+-spec process_dir(path(), [path()], disco_gbset(binary()), disco_gbset(jobname())) -> ok.
 process_dir(_DataRoot, [], _Purged, _Active) -> ok;
 process_dir(DataRoot, [Dir|R], Purged, Active) ->
     Path = filename:join(DataRoot, Dir),
@@ -64,7 +64,7 @@ process_dir(DataRoot, [Dir|R], Purged, Active) ->
          || Job <- Jobs, ifdead(Job, Active)],
     process_dir(DataRoot, R, Purged, Active).
 
--spec ifdead(jobname(), gb_set()) -> boolean().
+-spec ifdead(jobname(), disco_gbset(jobname())) -> boolean().
 ifdead(Job, Active) ->
     not gb_sets:is_member(Job, Active).
 
@@ -79,7 +79,7 @@ purge_job(Job, JobPath) ->
     _ = os:cmd("rm -Rf " ++ JobPath),
     ok.
 
--spec process_job(path(), gb_set()) -> ok.
+-spec process_job(path(), disco_gbset(binary())) -> ok.
 process_job(JobPath, Purged) ->
     case prim_file:read_file_info(JobPath) of
         {ok, #file_info{type = directory, mtime = TStamp}} ->

--- a/master/src/worker_inputs.erl
+++ b/master/src/worker_inputs.erl
@@ -7,19 +7,18 @@
 -include("disco.hrl").
 -include("pipeline.hrl").
 
--record(state, {
-          % seq_id() -> {input_id(), data_input()}
-          inputs     = gb_trees:empty() :: gb_tree(),
-          % {seq_id(), rep_id()} -> fail_info()
-          input_map  = gb_trees:empty() :: gb_tree(),
-          max_seq_id                    :: seq_id()}).
--type state() :: #state{}.
-
 -record(fail_info, {url       :: url(),
                     last_fail :: erlang:timestamp()}).
 -type fail_info() :: #fail_info{}.
 
--type seq_id() :: non_neg_integer().
+-record(state, {
+          % seq_id() -> {input_id(), data_input()}
+          inputs     = gb_trees:empty() :: disco_gbtree(seq_id(), {input_id(), data_input()}),
+          % {seq_id(), rep_id()} -> fail_info()
+          input_map  = gb_trees:empty() :: disco_gbtree({seq_id(), rep_id()}, fail_info()),
+          max_seq_id                    :: seq_id()}).
+-type state() :: #state{}.
+
 -type rep_id() :: non_neg_integer().
 
 -type replica() :: [rep_id() | url(), ...].
@@ -56,7 +55,7 @@ all(S) ->
     include(all_seq_ids(S), S).
 
 -spec replicas(seq_id(), rep_id(), label(), [{erlang:timestamp(), replica()}],
-               gb_tree()) -> {all | label(), [replica()]}.
+    disco_gbtree({seq_id(), rep_id()}, fail_info())) -> {all | label(), [replica()]}.
 replicas(SeqId, Rid, Label, Replicas, Map) ->
     case gb_trees:lookup({SeqId, Rid}, Map) of
         none ->

--- a/master/src/worker_runtime.erl
+++ b/master/src/worker_runtime.erl
@@ -22,9 +22,9 @@
                 save_info    :: string(),
 
                 child_pid       = none             :: none | non_neg_integer(),
-                failed_inputs   = gb_sets:empty()  :: gb_set(), % [seq_id()]
+                failed_inputs   = gb_sets:empty()  :: disco_gbset(seq_id()),
                 remote_outputs  = []               :: [remote_output()],
-                local_labels    = gb_trees:empty() :: gb_tree(),% label -> size
+                local_labels    = gb_trees:empty() :: disco_gbtree(label(), data_size()),
                 output_filename = none             :: none | path(),
                 output_file     = none             :: none | file:io_device()}).
 -type state() :: #state{}.
@@ -294,7 +294,7 @@ format_local_output({L, LocalFile, Size}, #state{jobname = JN, host = Host}) ->
 
 % Convert recorded outputs into pipeline format.
 
--spec local_results(jobname(), host(), path(), gb_tree()) -> dir_spec().
+-spec local_results(jobname(), host(), path(), disco_gbtree(label(), data_size())) -> dir_spec().
 local_results(JobName, Host, FileName, Labels) ->
     UPath = url_path(JobName, Host, FileName),
     Dir = erlang:iolist_to_binary(io_lib:format("dir://~s/~s", [Host, UPath])),


### PR DESCRIPTION
These types can serve as a good documentation and make dialyzer's job easier.
We still cannot remove the nowarn_deprecated_type because of dialyzer's problem
with worker_throttle.
