### PR TITLE
worker_runtime: allow sending "more" in inputs.

### DIFF
--- a/master/src/worker_inputs.erl
+++ b/master/src/worker_inputs.erl
@@ -1,6 +1,7 @@
 -module(worker_inputs).
 
--export([init/3, all/1, include/2, exclude/2, fail/3, failed_info/2]).
+-export([init/3, all/1, include/2, exclude/2, fail/3, failed_info/2,
+         is_input_done/1]).
 -export_type([state/0, worker_input/0]).
 
 -include("common_types.hrl").
@@ -16,6 +17,7 @@
           inputs     = gb_trees:empty() :: disco_gbtree(seq_id(), {input_id(), data_input()}),
           % {seq_id(), rep_id()} -> fail_info()
           input_map  = gb_trees:empty() :: disco_gbtree({seq_id(), rep_id()}, fail_info()),
+          is_input_done                 :: boolean(),
           max_seq_id                    :: seq_id()}).
 -type state() :: #state{}.
 
@@ -31,6 +33,8 @@ init(Inputs, Grouping, Group) ->
                             || {SeqId, {_Id, DI}} <- SeqInputs]),
     #state{inputs     = gb_trees:from_orddict(SeqInputs),
            input_map  = gb_trees:from_orddict(SeqMap),
+           %TODO only set input as done when we know it is done.
+           is_input_done = true,
            max_seq_id = length(Inputs)}.
 
 -spec init_replicas(seq_id(), data_input(), label_grouping(), group())
@@ -44,6 +48,10 @@ init_replicas(SeqId, DI, Grouping, Group) ->
 include(SeqIds, #state{input_map = Map}) ->
     [{SeqId, L, Reps} || SeqId <- SeqIds,
                          {L, Reps} <- [replicas(SeqId, 0, 0, [], Map)]].
+
+-spec is_input_done(state()) -> boolean().
+is_input_done(#state{is_input_done = Done}) ->
+    Done.
 
 -spec exclude([seq_id()], state()) -> [worker_input()].
 exclude(Exc, S) ->


### PR DESCRIPTION
The runtime used to tell the worker that there is no more inputs in all of the
cases.  In the new model, the runtime will tell the worker that there is more
inputs in case there is more inputs to come.

At the moemnt, the runtime has all of the inputs when the task starts but this
will change with the concurrent stages.
