### PR TITLE
erlang: avoid creating an extra fun when calling spawn_link.

### DIFF
--- a/master/src/ddfs/ddfs_http.erl
+++ b/master/src/ddfs/ddfs_http.erl
@@ -13,7 +13,7 @@ http_put(SrcPath, DstUrl, Timeout) ->
         spawn(fun() ->
             process_flag(trap_exit, true),
             S = self(),
-            spawn_link(fun() -> http_client:http_put_conn(SrcPath, DstUrl, S) end),
+            spawn_link(http_client, http_put_conn, [SrcPath, DstUrl, S]),
             receive
                 {'EXIT', _, _} = E -> P ! {S, ddfs_util, {error, E}}, ok;
                 E -> P ! {S, ddfs_util, E}, ok

--- a/master/src/ddfs/ddfs_master.erl
+++ b/master/src/ddfs/ddfs_master.erl
@@ -164,7 +164,7 @@ init(_Args) ->
         || Name <- [get_tags, do_get_tags_all, do_get_tags_filter,
             do_get_tags_safe, do_get_tags_gc]],
     spawn_link(fun() -> monitor_diskspace() end),
-    spawn_link(fun() -> ddfs_gc:start_gc(disco:get_setting("DDFS_DATA")) end),
+    spawn_link(ddfs_gc, start_gc, [disco:get_setting("DDFS_DATA")]),
     Refresher = spawn_link(fun() -> refresh_tag_cache_proc() end),
     put(put_port, disco:get_setting("DDFS_PUT_PORT")),
     {ok, #state{cache_refresher = Refresher}}.

--- a/master/src/disco_server.erl
+++ b/master/src/disco_server.erl
@@ -445,7 +445,7 @@ do_gc_blacklist(Hosts, S) ->
 -spec start_worker(host(), pid(), task()) -> pid().
 start_worker(H, NM, {#task_spec{jobname = J, stage = S, taskid = TI}, _} = T) ->
     event_server:event(J, "~s:~B assigned to ~s", [S, TI, H], none),
-    spawn_link(fun() -> disco_worker:start_link_remote(H, NM, T) end).
+    spawn_link(disco_worker, start_link_remote, [H, NM, T]).
 
 -spec schedule_next() -> ok.
 schedule_next() ->

--- a/master/src/disco_worker.erl
+++ b/master/src/disco_worker.erl
@@ -43,8 +43,7 @@ start_link_remote(Host, NodeMon, Task) ->
     wait_until_node_ready(NodeMon, Host),
     process_flag(trap_exit, true),
     {Master, Self} = {node(), self()},
-    spawn_link(Node, fun() -> disco_worker:start_link(Self, Master, Task)
-                     end),
+    spawn_link(Node, disco_worker, start_link, [Self, Master, Task]),
     receive
         {'EXIT', _, Reason} -> exit({error, Reason});
         ok      -> ok;

--- a/master/src/hdfs.erl
+++ b/master/src/hdfs.erl
@@ -12,8 +12,7 @@ get_data_node_link(NameNode, HdfsPath, User) ->
 save_to_hdfs(NameNode, HdfsPath, User, LocalPath) ->
     DataNodeUrl = get_data_node_link(NameNode, HdfsPath, User),
     Self = self(),
-    spawn_link(fun() -> http_client:http_put_conn(LocalPath, DataNodeUrl,
-                    Self) end),
+    spawn_link(http_client, http_put_conn, [LocalPath, DataNodeUrl, Self]),
     receive S ->
             error_logger:info_msg("Hdfs operation done: ~p~n", [S]),
             S

--- a/master/src/node_mon.erl
+++ b/master/src/node_mon.erl
@@ -124,11 +124,11 @@ is_master(Host) ->
 start_temp_gc(Host, Node, DiscoRoot) ->
     DataRoot = filename:join(DiscoRoot, Host),
     Master = node(),
-    spawn_link(Node, fun() -> temp_gc:start_link(Master, DataRoot) end).
+    spawn_link(Node, temp_gc, start_link, [Master, DataRoot]).
 
 -spec start_lock_server(node()) -> pid().
 start_lock_server(Node) ->
-    spawn_link(Node, fun lock_server:start_link/0).
+    spawn_link(Node, lock_server, start_link, []).
 
 -spec start_ddfs_node(host(), node(), path(), node_ports(),
                       {boolean(), boolean()}) -> pid().
@@ -141,4 +141,4 @@ start_ddfs_node(Host, Node, DiscoRoot,
             {get_port, GetPort}, {put_port, PutPort},
             {get_enabled, GetEnabled}, {put_enabled, PutEnabled}],
     NodeMon = self(),
-    spawn_link(Node, fun() -> ddfs_node:start_link(Args, NodeMon) end).
+    spawn_link(Node, ddfs_node, start_link, [Args, NodeMon]).


### PR DESCRIPTION
This commit replaces some of spawn_link(Fun) and spawn_link(Node, Fun) with
spawn_link(Module, Function, Args) and spawn_link(Node, Module, Function, Args)
respectively.  The latter forms are prefered because of their simplicity.
