### PR TITLE
job_coordinator: add the tasks which are scheduled for re_run to the pen...

### DIFF
--- a/master/src/job_coordinator.erl
+++ b/master/src/job_coordinator.erl
@@ -403,7 +403,7 @@ retry_task(Host, _Error,
                                         stage   = Stage},
                       failed_count = FailedCnt,
                       failed_hosts = FH} = TInfo,
-           #state{tasks = Tasks, hosts = Cluster} = S) ->
+           #state{tasks = Tasks, hosts = Cluster, pending = Pending} = S) ->
     {ok, MaxFail} = application:get_env(max_failure_rate),
     FC = FailedCnt + 1,
     case FC > MaxFail of
@@ -439,7 +439,8 @@ retry_task(Host, _Error,
                 end,
             TInfo1 = TInfo#task_info{failed_count = FC,
                                      failed_hosts = Blacklist},
-            S#state{tasks = jc_utils:update_task_info(TaskId, TInfo1, Tasks)}
+            S#state{tasks = jc_utils:update_task_info(TaskId, TInfo1, Tasks),
+                    pending = [{TaskId, re_run}|Pending]}
     end.
 
 -spec do_kill_job(term(), state()) -> ok.


### PR DESCRIPTION
...ding list.

One of the benefits of this approach is that when a new input is available for
this task, we know that it is not finished yet and needs the task spec to be
updated.  Otherwise, the task will be re-launched with all of the inputs but
still waiting for more inputs.
