### PR TITLE
fix permissions for /var/run/sshd

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -12,6 +12,7 @@ RUN adduser --system disco --shell /bin/sh
 # setup ssh
 RUN echo root:disco | chpasswd
 RUN mkdir -p /var/run/sshd
+RUN chmod 0600 /var/run/sshd
 
 ## passwordless login for docker 
 RUN mkdir -p /home/disco/.ssh


### PR DESCRIPTION
sshd refuses to start because the default permissions from mkdir is too liberal.
