### PR TITLE
When retrying failed blobs, seek the input stream to the beginning becau...

### DIFF
--- a/lib/disco/ddfs.py
+++ b/lib/disco/ddfs.py
@@ -385,6 +385,7 @@ class DDFS(object):
                     for url in self._upload(urls, source, to_master=False, **kwargs)]
         except CommError as e:
             scheme, (host, port), path = urlsplit(e.url)
+            source.seek(0)  # source will be read again; seek to the beginning
             return self._push((source, target),
                               replicas=replicas,
                               forceon=forceon,


### PR DESCRIPTION
When a CommError occurs during a blob upload, the source stream pointer needs to be reset to the beginning. Otherwise, the source will be read starting from wherever it happened to fail in the previous try.
