### PR TITLE
ddfs cat: do not wait on unavailable replicas.

### DIFF
--- a/bin/ddfscli.py
+++ b/bin/ddfscli.py
@@ -82,7 +82,7 @@ def cat(program, *urls):
         for replica in replicas:
             try:
                 return download(proxy_url(urlresolve(replica, master=program.ddfs.master),
-                                          to_master=False))
+                                          to_master=False), sleep=9)
             except Exception as e:
                 sys.stderr.write("{0}\n".format(e))
         if not ignore_missing:

--- a/lib/disco/comm.py
+++ b/lib/disco/comm.py
@@ -80,13 +80,13 @@ def request(method, url, data=None, headers={}, sleep=0):
         raise CommError(response.read(), url, status)
     return response
 
-def download(url, method='GET', data=None, offset=(), token=None):
+def download(url, method='GET', data=None, offset=(), token=None, sleep=0):
     headers = range_header(offset)
     headers.update(auth_header(token))
     return request(method if data is None else 'POST',
                    url,
                    data=data,
-                   headers=headers).read()
+                   headers=headers, sleep=sleep).read()
 
 def upload(urls, source, token=None, **kwargs):
     data = FileSource(source).read()


### PR DESCRIPTION
If ddfs cat fails to obtain the contents of a replica, it can immediately retry
another replica. There is no need to wait for it.  This commit closes issue 223.
