### PR TITLE
eventmonitor: update the extraction of jobinfo.

### DIFF
--- a/lib/disco/eventmonitor.py
+++ b/lib/disco/eventmonitor.py
@@ -171,7 +171,7 @@ class EventMonitor(object):
 
     @property
     def status(self):
-        return ("Status: [{0[0]}] {0[1]} waiting, {0[2]} running, {0[3]} done, {0[4]} failed"
+        return ("Status: [{0[0]}] {0[1]} waiting, {0[2]} pending, {0[3]} running, {0[4]} done, {0[5]} failed"
                 .format(tuple(self.stats)))
 
     def log_events(self):


### PR DESCRIPTION
The disco master now sends the number of pending tasks to the client. The client
has been updated to take this into account.
