### PR TITLE
ddfs_util: report the size of the found file to the file handler

### DIFF
--- a/master/src/ddfs/ddfs_gc_node.erl
+++ b/master/src/ddfs/ddfs_gc_node.erl
@@ -70,29 +70,26 @@ traverse(Now, Root, VolNames, Type) ->
     lists:foreach(
       fun(VolName) ->
               DDFSDir = filename:join([Root, VolName, Mode]),
-              Handler = fun(Obj, Dir, _Ok) ->
-                                handle_file(Obj, Dir, VolName, Type, Now)
+              Handler = fun(Obj, Size, Dir, _Ok) ->
+                                handle_file(Obj, Size, Dir, VolName, Type, Now)
                         end,
               ddfs_util:fold_files(DDFSDir, Handler, ok)
       end, VolNames).
 
--spec handle_file(path(), path(), volume_name(), object_type(), erlang:timestamp())
+-spec handle_file(path(), non_neg_integer(), path(),
+                  volume_name(), object_type(), erlang:timestamp())
                  -> 'ok'.
-handle_file("!trash" ++ _, _, _, _, _) ->
+handle_file("!trash" ++ _, _, _, _, _, _) ->
     ok;
 % GC1) Remove leftover !partial. files
-handle_file("!partial" ++ _ = File, Dir, _, _, Now) ->
+handle_file("!partial" ++ _ = File, _Size, Dir, _, _, Now) ->
     [_, Obj] = string:tokens(File, "."),
     {_, Time} = ddfs_util:unpack_objname(Obj),
     Diff = timer:now_diff(Now, Time) / 1000,
     Paranoid = disco:has_setting("DDFS_PARANOID_DELETE"),
     Path = filename:join(Dir, File),
     delete_if_expired(unknown, Path, Diff, ?PARTIAL_EXPIRES, Paranoid);
-handle_file(Obj, Dir, VolName, Type, _) ->
-    Size = case prim_file:read_file_info(filename:join(Dir, Obj)) of
-               {ok, #file_info{size = S}} -> S;
-               _E -> 0
-           end,
+handle_file(Obj, Size, _Dir, VolName, Type, _) ->
     ets:insert(Type, {list_to_binary(Obj), VolName, Size, false}).
 
 %%

--- a/master/src/ddfs/ddfs_node.erl
+++ b/master/src/ddfs/ddfs_node.erl
@@ -373,7 +373,7 @@ find_tags(Root, Vols) ->
     {ok,
      lists:foldl(fun({_Space, VolName}, Tags) ->
                          ddfs_util:fold_files(filename:join([Root, VolName, "tag"]),
-                                              fun(Tag, _, Tags1) ->
+                                              fun(Tag, _, _, Tags1) ->
                                                       parse_tag(Tag, VolName, Tags1)
                                               end, Tags)
                  end, gb_trees:empty(), Vols)}.

--- a/master/src/ddfs/ddfs_util.erl
+++ b/master/src/ddfs/ddfs_util.erl
@@ -215,7 +215,7 @@ diskspace(Path) ->
         _ -> {error, invalid_output}
     end.
 
--spec fold_files(string(), fun((string(), string(), T) -> T), T) -> T.
+-spec fold_files(string(), fun((string(), non_neg_integer(), string(), T) -> T), T) -> T.
 fold_files(Dir, Fun, Acc0) ->
     Base = Dir ++ "/",
     case prim_file:list_dir(Dir) of
@@ -226,8 +226,8 @@ fold_files(Dir, Fun, Acc0) ->
                       case prim_file:read_file_info(Path) of
                           {ok, #file_info{type = directory}} ->
                               fold_files(Path, Fun, Acc);
-                          _ ->
-                              Fun(F, Dir, Acc)
+                          {ok, #file_info{size = Size}} ->
+                              Fun(F, Size, Dir, Acc)
                       end
               end, Acc0, L);
         {error, Error} ->


### PR DESCRIPTION
This will help the handler avoid another call to prim_file:read_file_info to get
the size of the file.
