### PR TITLE
Adding systemd compat

### DIFF
--- a/contrib/systemd/disco.service
+++ b/contrib/systemd/disco.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Disco - Massive Data Minimal Code
+
+[Service]
+# User is optional depending on your installation
+#User=disco
+ExecStart=/usr/bin/disco nodaemon
+
+[Install]
+WantedBy=multi-user.target

--- a/lib/disco/cli.py
+++ b/lib/disco/cli.py
@@ -224,6 +224,9 @@ class Master(clx.server.Server):
         SchedulerOptions = ['+K', 'true',
                 '+P', '10000000']
 
+        if settings.get("SYSTEMD_ENABLED"):
+            SchedulerOptions.append("-noshell")
+
         for option, value in [('+scl', 'false'), ('+stbt', 's')]:
             if isErlOptionAvailable(option, value):
                 SchedulerOptions += [option, value] + ["-env", option, value]

--- a/lib/disco/settings.py
+++ b/lib/disco/settings.py
@@ -141,6 +141,11 @@ Possible settings for Disco are as follows:
                 We are assuming that the listening port is the default graphite
                 port.
 
+        .. envvar:: SYSTEMD_ENABLED
+
+                This adds -noshell to the erlang process. It provides compatibility for running
+                disco using a non-forking process type in the service definition.
+
         .. envvar:: DISCO_WORKER_MAX_MEM
 
                 How much memory can be used by worker in total. Worker calls `resource.setrlimit(RLIMIT_AS, limit) <http://docs.python.org/library/resource.html#resource.setrlimit>`_ to set the limit when it starts. Can be either a percentage of total available memory or an exact number of bytes. Note that ``setrlimit`` behaves differently on Linux and Mac OS X, see *man setrlimit* for more information. Default is ``80%`` i.e. 80% of the total available memory.
@@ -320,6 +325,8 @@ class DiscoSettings(Settings):
 #'PROFILE'
         'DISCO_PROFILE':         "'False'",
         'GRAPHITE_HOST':         "'localhost'",
+# OTHER
+        'SYSTEMD_ENABLED':       "'False'",
 # PROXY
         'DISCO_PROXY_ENABLED':   "''",
         'DISCO_PROXY':           "''",


### PR DESCRIPTION
Erlang terminates when using systemd unless -noshell is passed into the command line.
Included a systemd service definition as well.
