### PR TITLE
Systemd fixes

### DIFF
--- a/contrib/systemd/disco.service
+++ b/contrib/systemd/disco.service
@@ -3,7 +3,8 @@ Description=Disco - Massive Data Minimal Code
 
 [Service]
 # User is optional depending on your installation
-#User=disco
+# User=disco
+Environment="SYSTEMD_ENABLED=True"
 ExecStart=/usr/bin/disco nodaemon
 
 [Install]

--- a/lib/disco/cli.py
+++ b/lib/disco/cli.py
@@ -224,7 +224,7 @@ class Master(clx.server.Server):
         SchedulerOptions = ['+K', 'true',
                 '+P', '10000000']
 
-        if settings.get("SYSTEMD_ENABLED"):
+        if settings["SYSTEMD_ENABLED"]:
             SchedulerOptions.append("-noshell")
 
         for option, value in [('+scl', 'false'), ('+stbt', 's')]:


### PR DESCRIPTION
Systemd will now set the proper environment variable so settings files dont need to be changed. If the service starts with systemd it should run regardless of settings file now.

**NOTE** this runs in nodaemon so journald can handle the logging without any internals change (eg adding lager_syslog).
