### PR TITLE
job_coordinator: fix the return value of retry_task in case of failure

### DIFF
--- a/master/src/job_coordinator.erl
+++ b/master/src/job_coordinator.erl
@@ -424,7 +424,8 @@ retry_task(Host, _Error,
                              " At most ~B failures are allowed.",
                              [Stage, TaskId, FC, MaxFail]),
             job_event:task_event(JEHandler, {JobName, Stage, TaskId}, {<<"ERROR">>, M}),
-            kill_job(M);
+            kill_job(M),
+            S;
         false ->
             JobCoord = self(),
             _ = spawn_link(


### PR DESCRIPTION
This will fix the error messages when there are many task failures. Now the
erorr message clearly shows that the reason the job failed is because a single
task had many failures.
