### PR TITLE
Make task try to open input locally before going over the network.

### DIFF
--- a/lib/disco/schemes/scheme_disco.py
+++ b/lib/disco/schemes/scheme_disco.py
@@ -16,5 +16,6 @@ def input_stream(fd, size, url, params):
     """
     Opens the path on host locally if it is local, otherwise over http.
     """
-    file = open(url, task=globals().get('Task'))
+    import disco.worker
+    file = open(url, task=disco.worker.active_task)
     return file, len(file), file.url

--- a/lib/disco/schemes/scheme_discodb.py
+++ b/lib/disco/schemes/scheme_discodb.py
@@ -25,7 +25,8 @@ def Open(url, task=None):
     return discodb
 
 def input_stream(fd, size, url, params):
-    return Open(url, task=globals().get('Task')), size, url
+    import disco.worker
+    return Open(url, task=disco.worker.active_task), size, url
 
 class DiscoDBOutput(object):
     def __init__(self, stream, params):

--- a/lib/disco/schemes/scheme_hdfs.py
+++ b/lib/disco/schemes/scheme_hdfs.py
@@ -8,5 +8,6 @@ def open(url, task=None):
     return comm.open_url(http_url)
 
 def input_stream(fd, size, url, params):
-    file = open(url, task=globals().get('Task'))
+    import disco.worker
+    file = open(url, task=disco.worker.active_task)
     return file, len(file), file.url

--- a/lib/disco/schemes/scheme_http.py
+++ b/lib/disco/schemes/scheme_http.py
@@ -5,5 +5,6 @@ def open(url, task=None):
 
 def input_stream(fd, sze, url, params):
     """Opens the specified url using an http client."""
-    file = open(url, task=globals().get('Task'))
+    import disco.worker
+    file = open(url, task=disco.worker.active_task)
     return file, len(file), file.url

--- a/lib/disco/worker/classic/worker.py
+++ b/lib/disco/worker/classic/worker.py
@@ -309,6 +309,7 @@ class Worker(worker.Worker):
     def run(self, task, job, **jobargs):
         global Task
         Task = task
+        worker.active_task = task
         for key in self:
             self[key] = self.getitem(key, job, jobargs)
         assert self['version'] == '{0[0]}.{0[1]}'.format(sys.version_info[:2]), "Python version mismatch"

--- a/lib/disco/worker/pipeline/worker.py
+++ b/lib/disco/worker/pipeline/worker.py
@@ -198,6 +198,7 @@ class Worker(worker.Worker):
         # Entry point into the executing pipeline worker task.  This
         # initializes the task environment, sets up the current stage,
         # and then executes it.
+        worker.active_task = task
         for key in self:
             self[key] = self.getitem(key, job, jobargs)
         sys_version = '{0[0]}.{0[1]}'.format(sys.version_info[:2])


### PR DESCRIPTION
I noticed that my pipeline jobs were always opening the input's first replica, even if the input existed locally.  This fixes that and if the file is not local, it tries the other replicas in random order rather than always using the first.

Also I had issues with getting the global Task to work correctly with `__globals__`, and switched it to use a module global.
