### PR TITLE
DDFS: enable OS controlled  server socket size

### DIFF
--- a/master/rebar.config
+++ b/master/rebar.config
@@ -11,7 +11,7 @@
   {plists, "",
       {git, "https://github.com/discoproject/plists", {branch, "master"}}},
   {mochiweb, ".*",
-   {git, "https://github.com/mochi/mochiweb.git", {tag, "v2.9.2"}}}]}.
+   {git, "https://github.com/mochi/mochiweb.git", b66b68d95c9e1b2a32b194202e870e6d1e232eb7 }}]}.
 {xref_checks,
  % Remove 'exports_not_used' from default xref_checks since lager trips it.
  [undefined_function_calls]}.

--- a/master/src/ddfs/ddfs_put.erl
+++ b/master/src/ddfs/ddfs_put.erl
@@ -10,6 +10,7 @@
 
 % maximum file size: 1T
 -define(MAX_RECV_BODY, (1024*1024*1024*1024)).
+-define(RECV_CHUNK, (8192)).
 
 -spec start(non_neg_integer()) -> {ok, pid()} | {error, term()}.
 start(Port) ->
@@ -109,13 +110,13 @@ receive_blob(Req, IO, Dst, Url) ->
 
 -spec receive_body(module(), file:io_device()) -> _.
 receive_body(Req, IO) ->
-    R0 = (catch Req:stream_body(?MAX_RECV_BODY,
+    R0 = (catch Req:stream_body(?RECV_CHUNK,
                                 fun ({BufLen, Buf}, BodyLen) ->
                                         case file:write(IO, Buf) of
                                             ok -> BodyLen + BufLen;
                                             {error, _E} = Err -> throw(Err)
                                         end
-                                end, 0)),
+                                end, 0,?MAX_RECV_BODY)),
     case R0 of
         % R == <<>> or undefined if body is empty
         R when is_integer(R); R =:= <<>>; R =:= undefined ->

--- a/master/src/ddfs/ddfs_util.erl
+++ b/master/src/ddfs/ddfs_util.erl
@@ -262,7 +262,8 @@ start_web(Port, Func, Name) ->
     Ret = mochiweb_http:start([{name, Name},
                                {max, ?HTTP_MAX_CONNS},
                                {loop, Func},
-                               {port, Port}]),
+                               {port, Port},
+                               {recbuf,undefined}]),
     case Ret of
         {ok, _Pid} -> error_logger:info_msg("Started ~p at ~p on port ~p",
                                             [Name, node(), Port]);


### PR DESCRIPTION
Fixes #603 
Sets the TCP socket buffer size to OS controlled

Based on changes in current mochiweb upstream https://github.com/mochi/mochiweb/issues/153, therefore update mochiweb version.
Streaming body size set to the previous default socket size(8KB).
Should be further investigated if the size influences performance or should be configurable.
Did a small test with 1MB, but did not change results.
