### PR TITLE
Python 3 persistent_hash was broken.  Go back to builtin hash instead.

### DIFF
--- a/examples/util/estimate_pi.py
+++ b/examples/util/estimate_pi.py
@@ -15,4 +15,4 @@ if __name__ == '__main__':
     tot = 0
     for k, v in result_iterator(job.wait()):
         tot += v
-    print (4.0 * tot) / COUNT
+    print ((4.0 * tot) / COUNT)

--- a/lib/disco/compat.py
+++ b/lib/disco/compat.py
@@ -42,10 +42,6 @@ if sys.version_info[0] == 3:
                 .format(sort_buffer_size, filename), True)
     integer_types = (int)
 
-    from hashlib import md5
-    def persistent_hash(input):
-        return int(md5(str_to_bytes(input)).hexdigest(), 16)
-
 else:
 
     basestring = basestring
@@ -85,7 +81,5 @@ else:
         return (["sort", "-z", "-t", '\xff', "-k", "1,1", "-T", ".",
                  "-S", sort_buffer_size,
                  "-o", filename, filename], False)
-
-    persistent_hash = hash
 
     integer_types = (int, long)

--- a/lib/disco/fileutils.py
+++ b/lib/disco/fileutils.py
@@ -13,6 +13,9 @@ MAX_RECORD_SIZE = 1 * MB
 HUNK_SIZE       = 1 * MB
 CHUNK_SIZE      = 64 * MB
 
+OS_SEPS         = os.sep + (os.altsep or '')
+
+
 class Chunker(object):
     """
     chunks contain hunks
@@ -137,7 +140,7 @@ class DiscoZipFile(ZipFile, object):
     def writepath(self, pathname, exclude=()):
         for file in files(pathname):
             name, ext = os.path.splitext(file)
-            if ext not in exclude:
+            if ext not in exclude and file.lstrip(OS_SEPS) not in self.NameToInfo:
                 self.write(file, file)
 
     def writemodule(self, module, arcname=None):

--- a/lib/disco/worker/classic/func.py
+++ b/lib/disco/worker/classic/func.py
@@ -7,7 +7,7 @@ This module defines the interfaces for the job functions,
 some default values, as well as otherwise useful functions.
 """
 import re
-from disco.compat import pickle_loads, pickle_dumps, bytes_to_str, str_to_bytes, sort_cmd, persistent_hash
+from disco.compat import pickle_loads, pickle_dumps, bytes_to_str, str_to_bytes, sort_cmd
 from disco.error import DataError
 from disco.worker.task_io import *
 
@@ -126,7 +126,7 @@ def init(input_iter, params):
     """
 
 def default_partition(key, nr_partitions, params):
-    return persistent_hash(key) % nr_partitions
+    return hash(key) % nr_partitions
 
 def make_range_partition(min_val, max_val):
     """


### PR DESCRIPTION
I was trying the examples/util/estimate_pi.py example on a Python 3 Disco installation and it was failing in a call to persistent_hash because it was trying to run str_to_bytes on an integer and failing because it has no 'encode' method.

I see from the discussion groups that at least one other person has had a problem with this persistent_hash.

Having looked at it I can't see any reason why the Python 3 code can't use the builtin 'hash' function just like the Python 2 code does.

It's hard so second guess the reason as to why the persistent_hash function was added.  At least as far as the estimate_pi example goes I get an answer instead of an exception (as long as I fix the print statement at the bottom of the file).

Giles
