### PR TITLE
Add ddfs du support

### DIFF
--- a/lib/disco/fileutils.py
+++ b/lib/disco/fileutils.py
@@ -248,3 +248,14 @@ def get_valid_path(path):
         return os.path.realpath(path)
     else:
         return path
+
+def human_readable_size(size):
+    import math
+    if size == 0:
+        return '0 B'
+
+    size_name = ("B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB")
+    i = int(math.floor(math.log(size, 1024)))
+    p = math.pow(1024, i)
+    s = round(size/p, 2)
+    return '%s %s' % (s, size_name[i])


### PR DESCRIPTION
This feature runs a job on the cluster on the tags specified to find the _unreplicated_ size of the data on the filesystem. It may not be 100% accurate if there is a missing replica, but it will try and avoid downloading from another node (and thus not being able to find the size locally).

Usage: ddfs du <tag> [-H/-P/-n]

For larger tags you will want to increase the partitions and number of cores available to the job (-P and -n respectively).
If you would like human readable output (or just hate doing math) you can use -H and it will output similar to the following:

$ ddfs du chekov -H
chekov: 7.82 MB

This will cause extra load on the cluster, and large tags might take a while to come back with a result.
