### PR TITLE
Fix formatting of sizes between 1000 and 1024

### DIFF
--- a/master/www/js/disco.js
+++ b/master/www/js/disco.js
@@ -13,7 +13,8 @@ $(document).ready(function(){
 function format_size(num){
     units = ['KB', 'MB', 'GB', 'TB'];
     for (i = 0; i < units.length; i++) {
-        if (num < 1024)
+        // Don't use 1024 here otherwise (1023).toPrecision(3) becomes 1.02e+3
+        if (num < 1000)
             return num.toPrecision(3) + units[i];
         num /= 1024;
     }


### PR DESCRIPTION
`(1013).toPrecision(3)` becomes `1.01e+3` which results in a quite ugly `1.01e+3GB`. With this fix it becomes `0.987TB`
