### PR TITLE
remove unnecessary files added to the worker zipfile

### DIFF
--- a/lib/disco/worker/__init__.py
+++ b/lib/disco/worker/__init__.py
@@ -239,8 +239,6 @@ class Worker(dict):
         jobzip = DiscoZipFile()
         jobzip.writepath(os.path.dirname(clxpath), exclude=('.pyc', '__pycache__'))
         jobzip.writepath(os.path.dirname(discopath), exclude=('.pyc', '__pycache__'))
-        jobzip.writesource(job)
-        jobzip.writesource(self)
         # Then, add any user-specified required files.
         from disco.util import iskv
         def get(key):


### PR DESCRIPTION
fix issue #622
Thanks to @ErikDubbelboer.

The newer versions of python print a warning message for duplicate files.
The file finder is able to add these files and add them to the zipfile.

To be tested on a three node cluster.
