### PR TITLE
make test fails on python3.5 with error ImportError: No module named urlparse

### DIFF
--- a/lib/disco/compat.py
+++ b/lib/disco/compat.py
@@ -32,6 +32,7 @@ if sys.version_info[0] == 3:
 
     import socketserver as socket_server
     from urllib.parse import urlencode
+    from urllib.parse import urlparse
     import http.client as httplib
     import http.server as http_server
 
@@ -76,6 +77,7 @@ else:
 
     import SocketServer as socket_server
     from urllib import urlencode
+    from urlparse import urlparse
     import httplib as httplib
     import BaseHTTPServer as http_server
 

--- a/lib/disco/util.py
+++ b/lib/disco/util.py
@@ -7,7 +7,6 @@ internally.
 """
 import os, sys, time
 import functools, gzip
-from urlparse import urlparse
 
 from disco.compat import BytesIO, basestring, bytes_to_str, str_to_bytes
 from disco.compat import pickle_loads, pickle_dumps, sort_cmd


### PR DESCRIPTION
Hi,

With reference to the below defect, opened for test failures on disco package on python3.5.  I have updated the disco code and also verified update code on python2.7 & python3.5 versions on both x86 & ppc64le architectures. 

https://github.com/discoproject/disco/issues/651

Thanks,
Snehlata Mohite.