### PR TITLE
Update to build with OTP 20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: erlang
 notification:
     email: false
 otp_release:
+  - 20.0
+  - 19.0
+  - 18.3
   - 18.2.1
   - 18.1
-  - 17.5
-  - 17.4

--- a/master/eunit.config
+++ b/master/eunit.config
@@ -7,4 +7,4 @@
    {git, "https://github.com/discoproject/mochiweb.git", {branch,
                                                              "discoproject"}}},
  {triq, ".*",
-   {git, "https://github.com/krestenkrab/triq.git", "master"}}]}.
+   {git, "https://github.com/triqng/triq.git", "master"}}]}.

--- a/master/eunit.config
+++ b/master/eunit.config
@@ -1,6 +1,6 @@
 {eunit_compile_opts, [debug_info, fail_on_warning,
                       {platform_define, "^[0-9]+", namespaced_types},
-                      {platform_define, "^(18|19|2\d+|\d{3,})", time_correction}]}.
+                      {platform_define, "^(18|19|2\\d+|\\d{3,})", time_correction}]}.
 {cover_enabled, true}.
 {deps,
  [{mochiweb, "",

--- a/master/include/pipeline.hrl
+++ b/master/include/pipeline.hrl
@@ -128,14 +128,14 @@
 -define(REDUCE_SHUFFLE, <<"reduce_shuffle">>).
 
 % The submitted pipeline jobpack.
--record(jobinfo, {jobname       :: jobname(),
-                  jobfile       :: path(),
+-record(jobinfo, {jobname = null :: null | jobname(),
+                  jobfile = null :: null | path(),
                   jobenvs = []  :: [{nonempty_string(), string()}],
                   owner         :: binary(),
                   worker        :: binary(),
                   inputs = []   :: [task_output()],
                   pipeline = [] :: pipeline(),
-                  schedule      :: task_schedule(),
+                  schedule = null :: null | task_schedule(),
                   save_results = false :: boolean(),
                   save_info     :: string()}).
 -type jobinfo() :: #jobinfo{}.

--- a/master/rebar.config
+++ b/master/rebar.config
@@ -2,11 +2,11 @@
  [debug_info, warn_missing_spec, warnings_as_errors, nowarn_deprecated_type,
   {parse_transform, lager_transform},
   {platform_define, "^[0-9]+", namespaced_types},
-  {platform_define, "^(18|19|2\d+|\d{3,})", time_correction}
+  {platform_define, "^(18|19|2\\d+|\\d{3,})", time_correction}
 ]}.
 {deps,
-[{lager, "2.0.3",
-   {git, "https://github.com/basho/lager.git", {tag, "2.0.3"}}},
+[{lager, "3.6.0",
+   {git, "https://github.com/erlang-lager/lager.git", {tag, "3.6.0"}}},
   {folsomite, "",
       {git, "https://github.com/discoproject/folsomite", {branch, "master"}}},
   {plists, "",

--- a/master/src/ddfs/ddfs_rebalance.erl
+++ b/master/src/ddfs/ddfs_rebalance.erl
@@ -103,7 +103,7 @@ weighted_select_items(L, K) ->
 weighted_select_items(_, 0, Items, _) ->
     Items;
 weighted_select_items(L, K, Items, Consumed) ->
-    P = random:uniform() * (1 - Consumed),
+    P = rand:uniform() * (1 - Consumed),
     {Item, Weight} = weighted_choose(L, P),
     Rest = lists:keydelete(Item, 1, L),
     weighted_select_items(Rest, K - 1, [Item|Items], Consumed + Weight).

--- a/master/src/ddfs/ddfs_tag.hrl
+++ b/master/src/ddfs/ddfs_tag.hrl
@@ -9,8 +9,8 @@
 
 -type attrib() :: 'urls' | 'read_token' | 'write_token' | {'user', binary()}.
 
--record(tagcontent, {id :: tagid(),
-                     last_modified :: binary(),
+-record(tagcontent, {id = null :: null | tagid(),
+                     last_modified = null :: null | binary(),
                      read_token = null :: token(),
                      write_token = null :: token(),
                      urls = [] :: [[binary()]],

--- a/master/src/disco_util.erl
+++ b/master/src/disco_util.erl
@@ -31,7 +31,7 @@ groupby(N, [H|_] = List, Groups) ->
 
 -spec choose_random([T,...]) -> T.
 choose_random(L) ->
-    lists:nth(random:uniform(length(L)), L).
+    lists:nth(rand:uniform(length(L)), L).
 
 -spec choose_random(list(T), non_neg_integer()) -> list(T).
 choose_random(L, N) ->

--- a/master/src/job_coordinator.erl
+++ b/master/src/job_coordinator.erl
@@ -300,7 +300,7 @@ do_use_inputs(Inputs, #state{jobinfo = JobInfo} = S) ->
                                     #task_info{spec = input,
                                                outputs = Inputs}}]),
     % Mark the 'input' stage as done, and send notification.
-    InputStage = #stage_info{all = 1, done = [input]},
+    InputStage = #stage_info{start = disco_util:timestamp(), all = 1, done = [input]},
     SI = gb_trees:from_orddict([{?INPUT, InputStage}]),
     stage_done(?INPUT),
     S#state{jobinfo    = JobInfo#jobinfo{inputs = Inputs},

--- a/master/src/job_coordinator.erl
+++ b/master/src/job_coordinator.erl
@@ -433,7 +433,7 @@ retry_task(Host, _Error,
                           Sleep =
                               lists:min([FC * ?FAILED_MIN_PAUSE,
                                          ?FAILED_MAX_PAUSE])
-                              + random:uniform(?FAILED_PAUSE_RANDOMIZE),
+                              + rand:uniform(?FAILED_PAUSE_RANDOMIZE),
                           M = "Task ~s:~B failed on ~p, ~Bth failures so far."
                               " Sleeping ~B seconds before retrying.",
                           MArgs = [Stage, TaskId, Host, FC, round(Sleep / 1000)],

--- a/master/src/jobpack.erl
+++ b/master/src/jobpack.erl
@@ -405,6 +405,8 @@ schedule_option1(#ver1_info{force_local = Local, force_remote = Remote, max_core
     S = schedule_option1(Local, Remote),
     S#task_schedule{max_cores = Max}.
 % Prefer Local if both Local and Remote are set.
-schedule_option1(true, _) -> #task_schedule{locality = local};
-schedule_option1(_, true) -> #task_schedule{locality = remote};
-schedule_option1(_, _)    -> #task_schedule{}.
+schedule_option1(true, _) -> #task_schedule{locality = local,
+											max_cores = ?DEFAULT_MAX_CORE};
+schedule_option1(_, true) -> #task_schedule{locality = remote,
+											max_cores = ?DEFAULT_MAX_CORE};
+schedule_option1(_, _)    -> #task_schedule{max_cores = ?DEFAULT_MAX_CORE}.


### PR DESCRIPTION
This enables Disco to run on OTP 20. Also, discontinues the support for OTP 17 since the "random" module is now deprecated.